### PR TITLE
feat: add generic props type for UseFocusableConfig

### DIFF
--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -15,7 +15,7 @@ import {
 } from './SpatialNavigation';
 import { useFocusContext } from './useFocusedContext';
 
-export interface UseFocusableConfig {
+export interface UseFocusableConfig<P = object> {
   focusable?: boolean;
   saveLastFocusedChild?: boolean;
   trackChildren?: boolean;
@@ -23,24 +23,24 @@ export interface UseFocusableConfig {
   isFocusBoundary?: boolean;
   focusKey?: string;
   preferredChildFocusKey?: string;
-  onEnterPress?: (props: object, details: KeyPressDetails) => void;
-  onEnterRelease?: (props: object) => void;
+  onEnterPress?: (props: P, details: KeyPressDetails) => void;
+  onEnterRelease?: (props: P) => void;
   onArrowPress?: (
     direction: string,
-    props: object,
+    props: P,
     details: KeyPressDetails
   ) => boolean;
   onFocus?: (
     layout: FocusableComponentLayout,
-    props: object,
+    props: P,
     details: FocusDetails
   ) => void;
   onBlur?: (
     layout: FocusableComponentLayout,
-    props: object,
+    props: P,
     details: FocusDetails
   ) => void;
-  extraProps?: object;
+  extraProps?: P;
 }
 
 export interface UseFocusableResult {
@@ -56,7 +56,7 @@ export interface UseFocusableResult {
   updateAllLayouts: () => void;
 }
 
-const useFocusableHook = ({
+const useFocusableHook = <P>({
   focusable = true,
   saveLastFocusedChild = true,
   trackChildren = false,
@@ -70,7 +70,7 @@ const useFocusableHook = ({
   onFocus = noop,
   onBlur = noop,
   extraProps
-}: UseFocusableConfig = {}): UseFocusableResult => {
+}: UseFocusableConfig<P> = {}): UseFocusableResult => {
   const onEnterPressHandler = useCallback(
     (details: KeyPressDetails) => {
       onEnterPress(extraProps, details);

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -15,6 +15,31 @@ import {
 } from './SpatialNavigation';
 import { useFocusContext } from './useFocusedContext';
 
+export type EnterPressHandler<P = object> = (
+  props: P,
+  details: KeyPressDetails
+) => void;
+
+export type EnterReleaseHandler<P = object> = (props: P) => void;
+
+export type ArrowPressHandler<P = object> = (
+  direction: string,
+  props: P,
+  details: KeyPressDetails
+) => boolean;
+
+export type FocusHandler<P = object> = (
+  layout: FocusableComponentLayout,
+  props: P,
+  details: FocusDetails
+) => void;
+
+export type BlurHandler<P = object> = (
+  layout: FocusableComponentLayout,
+  props: P,
+  details: FocusDetails
+) => void;
+
 export interface UseFocusableConfig<P = object> {
   focusable?: boolean;
   saveLastFocusedChild?: boolean;
@@ -23,23 +48,11 @@ export interface UseFocusableConfig<P = object> {
   isFocusBoundary?: boolean;
   focusKey?: string;
   preferredChildFocusKey?: string;
-  onEnterPress?: (props: P, details: KeyPressDetails) => void;
-  onEnterRelease?: (props: P) => void;
-  onArrowPress?: (
-    direction: string,
-    props: P,
-    details: KeyPressDetails
-  ) => boolean;
-  onFocus?: (
-    layout: FocusableComponentLayout,
-    props: P,
-    details: FocusDetails
-  ) => void;
-  onBlur?: (
-    layout: FocusableComponentLayout,
-    props: P,
-    details: FocusDetails
-  ) => void;
+  onEnterPress?: EnterPressHandler<P>;
+  onEnterRelease?: EnterReleaseHandler<P>;
+  onArrowPress?: ArrowPressHandler<P>;
+  onFocus?: FocusHandler<P>;
+  onBlur?: BlurHandler<P>;
   extraProps?: P;
 }
 


### PR DESCRIPTION
When using the app, there are certain instances where I pass down the navigation callback functions to a child component and I would like to know what the props will be.

With the `extraProps` field declared as an `object`, it is kind of difficult to gauge what is there unless I explicitly cast the props to a separate variable to show the intended keys.

In this change, I have added a generic type (defaults to `object`) that gets passed to the `UseFocusableConfig`. With this, a developer can specify a model and then in the parent component, can declare the `props` argument to match without the need to cast. 