### PR TITLE
Update setKeyCode API to allow mapping direction to multiple keyCodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,23 @@ When this feature is enabled, it will also throttle rapidly fired key presses (r
 Method to set custom key codes. I.e. when the device key codes differ from a standard browser arrow key codes.
 ```jsx
 setKeyMap({
-  'left': 9001,
-  'up': 9002,
-  'right': 9003,
-  'down': 9004,
-  'enter': 9005
+  left: 9001,
+  up: 9002,
+  right: 9003,
+  down: 9004,
+  enter: 9005
+});
+```
+
+There is also support for mapping multiple key codes to a single direction. This can be useful when working with gamepads that utilize a joystick and a directional pad and you want to make use of both.
+
+```jsx
+setKeyMap({
+  left: [205, 214],
+  up: [203, 211],
+  right: [206, 213],
+  down: [204, 212],
+  enter: [195]
 });
 ```
 

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -120,9 +120,9 @@ export interface FocusDetails {
   event?: KeyboardEvent;
 }
 
-export type KeyMap = { [index: string]: number[] };
+export type BackwardsCompatibleKeyMap = { [index: string]: number | number[] };
 
-export type LegacyKeyMap = { [index: string]: number };
+export type KeyMap = { [index: string]: number[] };
 
 const getChildClosestToOrigin = (children: FocusableComponent[]) => {
   const childrenClosestToOrigin = sortBy(
@@ -134,10 +134,10 @@ const getChildClosestToOrigin = (children: FocusableComponent[]) => {
 };
 
 /**
- * Takes either a KeyMap or a LegacyKeyMap and transforms it into a the new KeyMap format
+ * Takes either a BackwardsCompatibleKeyMap and transforms it into a the new KeyMap format
  * to ensure backwards compatibility.
  */
-const normalizeLegacyKeyMap = (keyMap: KeyMap | LegacyKeyMap) => {
+const normalizeKeyMap = (keyMap: BackwardsCompatibleKeyMap) => {
   const newKeyMap: KeyMap = {};
 
   Object.entries(keyMap).forEach(([key, value]) => {
@@ -1276,10 +1276,10 @@ class SpatialNavigationService {
     return this.keyMap;
   }
 
-  setKeyMap(keyMap: KeyMap | LegacyKeyMap) {
+  setKeyMap(keyMap: BackwardsCompatibleKeyMap) {
     this.keyMap = {
       ...this.getKeyMap(),
-      ...normalizeLegacyKeyMap(keyMap)
+      ...normalizeKeyMap(keyMap)
     };
   }
 


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/NoriginMedia/Norigin-Spatial-Navigation/issues/28), I would like to add support for multiple keyCode mapping.  This will be necessary for users who plan to use a gamepad with a joystick and a d-pad.  