### PR TITLE
Added function for retrieving current focus key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.0.6]
+## Added
+- Function (`getCurrentFocusKey`) for retrieving the currently focused component's focus key
+
 # [1.0.5]
 ## Added
 - Added generic P type for the props passed to `useFocusable` hook that is available in all callbacks that bounce props back.

--- a/README.md
+++ b/README.md
@@ -358,6 +358,9 @@ Only works when `trackChildren` is enabled!
 String that contains the focus key for the component. It is either the same as `focusKey` passed to the hook params,
 or an automatically generated one.
 
+#### `getCurrentFocusKey` (function) `() => string`
+Returns the currently focused component's focus key.
+
 ##### `navigateByDirection` (function) `(direction: string, focusDetails: FocusDetails) => void`
 Method to manually navigation to a certain direction. I.e. you can assign a mouse-wheel to navigate Up and Down.
 Also useful when you have some "Arrow-like" UI in the app that is meant to navigate in certain direction when pressed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "React hooks based Spatial Navigation solution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,7 +139,8 @@ function Menu({ focusKey: focusKeyParam }: MenuProps) {
     // navigateByDirection, -- to manually navigate by direction
     // pause, -- to pause all navigation events
     // resume, -- to resume all navigation events
-    // updateAllLayouts -- to force update all layouts when needed
+    // updateAllLayouts, -- to force update all layouts when needed
+    // getCurrentFocusKey -- to get the current focus key
   } = useFocusable({
     focusable: true,
     saveLastFocusedChild: false,

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -519,6 +519,7 @@ class SpatialNavigationService {
     this.navigateByDirection = this.navigateByDirection.bind(this);
     this.init = this.init.bind(this);
     this.setKeyMap = this.setKeyMap.bind(this);
+    this.getCurrentFocusKey = this.getCurrentFocusKey.bind(this);
 
     this.debug = false;
     this.visualDebugger = null;
@@ -950,6 +951,13 @@ class SpatialNavigationService {
         ...rest
       );
     }
+  }
+
+  /**
+   * Returns the current focus key
+   */
+  getCurrentFocusKey(): string {
+    return this.focusKey;
   }
 
   /**

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -68,6 +68,7 @@ export interface UseFocusableResult {
   pause: () => void;
   resume: () => void;
   updateAllLayouts: () => void;
+  getCurrentFocusKey: () => string;
 }
 
 const useFocusableHook = <P>({
@@ -203,7 +204,8 @@ const useFocusableHook = <P>({
     navigateByDirection: SpatialNavigation.navigateByDirection,
     pause: SpatialNavigation.pause,
     resume: SpatialNavigation.resume,
-    updateAllLayouts: SpatialNavigation.updateAllLayouts
+    updateAllLayouts: SpatialNavigation.updateAllLayouts,
+    getCurrentFocusKey: SpatialNavigation.getCurrentFocusKey
   };
 };
 


### PR DESCRIPTION
This change addresses #27, allowing retrieval of the current focus key value, which can be used in a variety of magical ways. 🪄

## Added
- Function (`getCurrentFocusKey`) for retrieving the currently focused component's focus key

## Changed
- Updated documentation
- Version bumped to v1.0.6