### PR TITLE
Improved React Native documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ function Button() {
 }
 ```
 IMPORTANT TO NOTE:
-- [Native mode](#nativemode-boolean-default-false) needs to be **enabled** during initializing when using the library in a React Native environment
+- [Native mode](#nativemode-boolean-default-false) needs to be **enabled** during initialization when using the library in a React Native environment
 - In order to "sync" the focus events coming from the native focus engine to the hook, the `onFocus` callback needs to be linked with the `focusSelf` method. This way the hook will know that the component became focused and will set the `focused` flag accordingly.
 
 # API

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ function Button() {
 }
 ```
 IMPORTANT TO NOTE:
-- [Native mode](#nativemode-boolean-default-false) needs to be **enabled** when initializing
+- [Native mode](#nativemode-boolean-default-false) needs to be **enabled** during initializing when using the library in a React Native environment
 - In order to "sync" the focus events coming from the native focus engine to the hook, the `onFocus` callback needs to be linked with the `focusSelf` method. This way the hook will know that the component became focused and will set the `focused` flag accordingly.
 
 # API

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ function Button() {
 ```
 IMPORTANT TO NOTE:
 - [Native mode](#nativemode-boolean-default-false) needs to be **enabled** during initialization when using the library in a React Native environment
-- In order to "sync" the focus events coming from the native focus engine to the hook, the `onFocus` callback needs to be linked with the `focusSelf` method. This way the hook will know that the component became focused and will set the `focused` flag accordingly.
+- In order to "sync" the focus events coming from the native focus engine to the hook the `onFocus` callback needs to be linked with the `focusSelf` method. This way the hook will know that the component became focused and will set the `focused` flag accordingly.
 
 # API
 ## Top Level exports

--- a/README.md
+++ b/README.md
@@ -188,11 +188,6 @@ native focusable engine. This library is NOT doing any coordinates measurements 
 But it can still be used to keep the currently focused element node reference and its focused state, which can be used to
 highlight components based on the `focused` or `hasFocusedChild` flags.
 
-IMPORTANT TO NOTE:
-- [Native mode](#nativemode-boolean-default-false) needs to be **enabled** when initializing
-- In order to "sync" the focus events coming from the native focus engine to the hook, the `onFocus` callback needs to be linked with the `focusSelf` method.
-<br>(This way the hook will know that the component became focused and will set the `focused` flag accordingly.)
-
 ```jsx
 import { TouchableOpacity, Text } from 'react-native';
 import { useFocusable } from '@noriginmedia/norigin-spatial-navigation';
@@ -209,6 +204,9 @@ function Button() {
   </TouchableOpacity>);
 }
 ```
+IMPORTANT TO NOTE:
+- [Native mode](#nativemode-boolean-default-false) needs to be **enabled** when initializing
+- In order to "sync" the focus events coming from the native focus engine to the hook, the `onFocus` callback needs to be linked with the `focusSelf` method. This way the hook will know that the component became focused and will set the `focused` flag accordingly.
 
 # API
 ## Top Level exports

--- a/README.md
+++ b/README.md
@@ -187,9 +187,11 @@ In React Native environment the navigation between focusable (Touchable) compone
 native focusable engine. This library is NOT doing any coordinates measurements or navigation decisions in the native environment.
 But it can still be used to keep the currently focused element node reference and its focused state, which can be used to
 highlight components based on the `focused` or `hasFocusedChild` flags.
-IMPORTANT: in order to "sync" the focus events coming from the native focus engine to the hook, you have to link
-`onFocus` callback with the `focusSelf` method. This way, the hook will know that the component became focused, and will
-set the `focused` flag accordingly.
+
+IMPORTANT TO NOTE:
+- [Native mode](#nativemode-boolean-default-false) needs to be **enabled** when initializing
+- In order to "sync" the focus events coming from the native focus engine to the hook, the `onFocus` callback needs to be linked with the `focusSelf` method.
+<br>(This way the hook will know that the component became focused and will set the `focused` flag accordingly.)
 
 ```jsx
 import { TouchableOpacity, Text } from 'react-native';


### PR DESCRIPTION
Added a note about enabling native mode (ref. [comment](https://github.com/NoriginMedia/Norigin-Spatial-Navigation/issues/22#issuecomment-1240860303)) when using the library in a React Native environment, as well as some small formatting and readability changes.

---

#### Added:
- _README.md_
  - React Native documentation note that `nativeMode` should be enabled

#### Changes:
- _README.md_
  - React Native documentation formatting, readability, etc.