### PR TITLE
accept `focusDetails` argument in `focusSelf`

### DIFF
--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -133,9 +133,12 @@ const useFocusableHook = <P>({
     [propFocusKey]
   );
 
-  const focusSelf = useCallback(() => {
-    SpatialNavigation.setFocus(focusKey);
-  }, [focusKey]);
+  const focusSelf = useCallback(
+    (focusDetails: FocusDetails = {}) => {
+      SpatialNavigation.setFocus(focusKey, focusDetails);
+    },
+    [focusKey]
+  );
 
   useEffectOnce(() => {
     const node = ref.current;


### PR DESCRIPTION
An application scrolls to an element in `onFocus` handler. `onFocus` can be called either automatically (for example, on page load) or in response of user action (keyboard event or, in case of webOS, mouse event). For the sake of convenience, cursor hover on webOS is handled by calling `focusSelf`

Because of UX, scroll on automatic focus has `behavior: 'instant'`, on user action — `behavior: 'smooth'`. But because there's no way to pass `MouseEvent` to `focusSelf`, there's no way to distinguish "mouse hover focus" from "page load focus". Accepting `focusDetails` argument in `focusSelf` would allow application to pass `MouseEvent` when it's necessary to do that and then do something like this:

```js
const onFocus = (layout, extraProps, focusDetails) => {
  scrollIntoViewIfNeeded(layout.node, {
    behavior:
      focusDetails?.event instanceof KeyboardEvent ||
      focusDetails?.event instanceof MouseEvent
        ? 'smooth'
        : 'instant',
  });
};
```

----

This change isn't critical, since application can call `setFocus(focusKey, { event })` instead of `focusSelf()`/`focusSelf({ event })`, but a shorter option is convenient to have