### PR TITLE
Added `react-is` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "typescript": "^4.5.5",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.7.4"
+    "webpack-dev-server": "^4.7.4",
+    "react-is": "^16.13.1"
   },
   "pre-commit": [
     "eslint"


### PR DESCRIPTION
Missing `react-is` devDep, so `npm start` is not working.