### PR TITLE
accept `focusDetails` argument in focusSelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.1.2]
+## Added
+- Param `focusDetails` in `focusSelf` and `setFocus` methods.
+
 # [1.1.1]
 ## Changed
 - Output bundle is now targeting ES5.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@noriginmedia/norigin-spatial-navigation",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React hooks based Spatial Navigation solution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -117,7 +117,9 @@ export interface KeyPressDetails {
  * Extra details passed from outside to be bounced back on other callbacks
  */
 export interface FocusDetails {
-  event?: KeyboardEvent;
+  event?: Event;
+  nativeEvent?: Event;
+  [key: string]: any;
 }
 
 export type BackwardsCompatibleKeyMap = { [index: string]: number | number[] };

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -60,11 +60,11 @@ export interface UseFocusableConfig<P = object> {
 
 export interface UseFocusableResult {
   ref: RefObject<any>; // <any> since we don't know which HTML tag is passed here
-  focusSelf: () => void;
+  focusSelf: (focusDetails?: FocusDetails) => void;
   focused: boolean;
   hasFocusedChild: boolean;
   focusKey: string;
-  setFocus: (focusKey: string) => void;
+  setFocus: (focusKey: string, focusDetails?: FocusDetails) => void;
   navigateByDirection: (direction: string, focusDetails: FocusDetails) => void;
   pause: () => void;
   resume: () => void;
@@ -133,9 +133,12 @@ const useFocusableHook = <P>({
     [propFocusKey]
   );
 
-  const focusSelf = useCallback(() => {
-    SpatialNavigation.setFocus(focusKey);
-  }, [focusKey]);
+  const focusSelf = useCallback(
+    (focusDetails: FocusDetails = {}) => {
+      SpatialNavigation.setFocus(focusKey, focusDetails);
+    },
+    [focusKey]
+  );
 
   useEffectOnce(() => {
     const node = ref.current;


### PR DESCRIPTION
Added `focusDetails` argument in `focusSelf` (and also in `setFocus`), as it was discussed at https://github.com/NoriginMedia/Norigin-Spatial-Navigation/pull/34

Also, I modified the `focusDetails` interface to include either an `event`, `nativeEvent` or any key-value combination required. This object will be received at the `onFocus` callback.

