### PR TITLE
Replaced Reflect.deleteProperty by delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.1.3]
+## Changed
+- `Reflect.deleteProperty` was replaced by `delete` to be es5 compliant.
+
 # [1.1.2]
 ## Added
 - Param `focusDetails` in `focusSelf` and `setFocus` methods.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@noriginmedia/norigin-spatial-navigation",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "React hooks based Spatial Navigation solution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -676,7 +676,7 @@ class SpatialNavigationService {
       this.keyUpEventListener = (event: KeyboardEvent) => {
         const eventType = this.getEventType(event.keyCode);
 
-        Reflect.deleteProperty(this.pressedKeys, eventType);
+        delete this.pressedKeys[eventType];
 
         if (this.throttle && !this.throttleKeypresses) {
           this.keyDownEventListenerThrottled.cancel();
@@ -1141,7 +1141,7 @@ class SpatialNavigationService {
     if (componentToRemove) {
       const { parentFocusKey } = componentToRemove;
 
-      Reflect.deleteProperty(this.focusableComponents, focusKey);
+      delete this.focusableComponents[focusKey];
 
       const parentComponent = this.focusableComponents[parentFocusKey];
       const isFocused = focusKey === this.focusKey;


### PR DESCRIPTION
Replaced `Reflect.deleteProperty` with `delete`, to be es5 compliant.
This fix resolve [issue #36](https://github.com/NoriginMedia/Norigin-Spatial-Navigation/issues/36)
