### PR TITLE
Back button handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Receives `extraProps` (see below) and `KeyPressDetails` as arguments.
 
 ##### `onBackPress` (function)
 Callback that is called when the component is focused and Back key is pressed.
-If no callback was provided to the focused component, the event will go up through the Focusable Tree as long as a one was finded or the top was reached up.
+If no callback was provided to the focused component, the event will go up through the Focusable Tree as long as a one was found or the top was reached up.
 Receives `extraProps` (see below) and `KeyPressDetails` as arguments.
 
 ##### `onEnterRelease` (function)

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ setKeyMap({
   up: 9002,
   right: 9003,
   down: 9004,
-  enter: 9005
+  enter: 9005,
+  back: 9006
 });
 ```
 
@@ -261,7 +262,8 @@ setKeyMap({
   up: [203, 211],
   right: [206, 213],
   down: [204, 212],
-  enter: [195]
+  enter: [195],
+  back: [196]
 });
 ```
 
@@ -322,6 +324,11 @@ I.e. when you have a Popup and you want some specific button to be focused inste
 
 ##### `onEnterPress` (function)
 Callback that is called when the component is focused and Enter key is pressed.
+Receives `extraProps` (see below) and `KeyPressDetails` as arguments.
+
+##### `onBackPress` (function)
+Callback that is called when the component is focused and Back key is pressed.
+If no callback was provided to the focused component, the event will go up through the Focusable Tree as long as a one was finded or the top was reached up.
 Receives `extraProps` (see below) and `KeyPressDetails` as arguments.
 
 ##### `onEnterRelease` (function)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@
  * Disabling ESLint rules for these dependencies since we know it is only for development purposes
  */
 
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import ReactDOMClient from 'react-dom/client';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -152,6 +152,7 @@ function Menu({ focusKey: focusKeyParam }: MenuProps) {
     onEnterPress: () => {},
     onEnterRelease: () => {},
     onArrowPress: () => true,
+    onBackPress: () => {},
     onFocus: () => {},
     onBlur: () => {},
     extraProps: { foo: 'bar' }
@@ -217,9 +218,13 @@ interface AssetProps {
 }
 
 function Asset({ title, color, onEnterPress, onFocus }: AssetProps) {
+  const withBackPress = useMemo(() => title === 'Asset 3', [title]);
   const { ref, focused } = useFocusable({
     onEnterPress,
     onFocus,
+    onBackPress: withBackPress? () => {
+      alert('Custom Back action');
+    }: undefined,
     extraProps: {
       title,
       color
@@ -229,7 +234,7 @@ function Asset({ title, color, onEnterPress, onFocus }: AssetProps) {
   return (
     <AssetWrapper ref={ref}>
       <AssetBox color={color} focused={focused} />
-      <AssetTitle>{title}</AssetTitle>
+      <AssetTitle>{withBackPress ? 'Asset 3 with Back' : title}</AssetTitle>
     </AssetWrapper>
   );
 }
@@ -363,7 +368,11 @@ const ScrollingRows = styled.div`
 `;
 
 function Content() {
-  const { ref, focusKey } = useFocusable();
+  const { ref, focusKey, setFocus } = useFocusable({
+    onBackPress(){
+      setFocus("MENU");
+    }
+  });
 
   const [selectedAsset, setSelectedAsset] = useState(null);
 

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -806,16 +806,8 @@ class SpatialNavigationService {
   onBackPress(keysDetails: KeyPressDetails) {
     const component = this.focusableComponents[this.focusKey];
 
-    /* Guard against last-focused component being unmounted at time of onEnterPress (e.g due to UI fading out) */
     if (!component) {
       this.log('onBackPress', 'noComponent');
-
-      return;
-    }
-
-    /* Suppress onBackPress if the last-focused item happens to lose its 'focused' status. */
-    if (!component.focusable) {
-      this.log('onBackPress', 'componentNotFocusable');
 
       return;
     }
@@ -828,16 +820,8 @@ class SpatialNavigationService {
   pressBackOnParent(keysDetails: KeyPressDetails, focusKey: string) {
     const component = this.focusableComponents[focusKey];
 
-    /* Guard against last-focused component being unmounted at time of onEnterPress (e.g due to UI fading out) */
     if (!component) {
       this.log('pressBackOnParent', 'noComponent');
-
-      return;
-    }
-
-    /* Suppress onEnterPress if the last-focused item happens to lose its 'focused' status. */
-    if (!component.focusable) {
-      this.log('pressBackOnParent', 'componentNotFocusable');
 
       return;
     }


### PR DESCRIPTION
Hi NoriginMedia,
me and my team are using your library in our react TV app and we made a small improvement in order to handle the back button.

The Back event could be handled defining the new `onBackPress` callback in the `useFocusable` configuration: this callback could be used in both component and Focusable Context.

As README.md explains, that callback is called when the component is focused and Back key is pressed. If no callback was provided to the focused component, the event will go up through the Focusable Tree as long as one defined callback was found or the top was reached up.

The `back` key is set to `27`, like the ESC key; of course it could be set with `setKeyMap` method.

A small example of the behaviour was provided on `App.tsx` demo page: when the back event was fired while the focus is on a `Content`, the focus jumps to the side menu; if the back event was fired while the focus is on the "Asset 3" element, an alert will show up.

I hope it could be usefull.

--Luca