### PR TITLE
add `trackFocused` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,11 @@ If this feature is disabled, the focus will be always on the first available chi
 This flag controls the feature of updating the `hasFocusedChild` flag returned to the hook output.
 Since you don't always need `hasFocusedChild` value, this feature is disabled by default for optimization purposes.
 
+##### `trackFocused` (default: true)
+This flag controls the feature of updating the `focused` flag returned to the hook output.
+Sometimes a component doesn't change when it is focused (for example, if it holds other focusable
+components), so if you don't use `focused` value, disable this feature for optimization purposes.
+
 ##### `autoRestoreFocus` (default: true)
 By default, when the currently focused component is unmounted (deleted), navigation service will try to restore the focus
 on the nearest available sibling of that component. If this behavior is undesirable, you can disable it by setting this

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -69,6 +69,7 @@ interface FocusableComponent {
   onUpdateHasFocusedChild: (hasFocusedChild: boolean) => void;
   saveLastFocusedChild: boolean;
   trackChildren: boolean;
+  trackFocused: boolean;
   preferredChildFocusKey?: string;
   focusable: boolean;
   isFocusBoundary: boolean;
@@ -82,6 +83,8 @@ interface FocusableComponentUpdatePayload {
   node: HTMLElement;
   preferredChildFocusKey?: string;
   focusable: boolean;
+  trackChildren: boolean,
+  trackFocused: boolean,
   isFocusBoundary: boolean;
   onEnterPress: (details?: KeyPressDetails) => void;
   onEnterRelease: () => void;
@@ -1099,6 +1102,7 @@ class SpatialNavigationService {
     onBlur,
     saveLastFocusedChild,
     trackChildren,
+    trackFocused,
     onUpdateFocus,
     onUpdateHasFocusedChild,
     preferredChildFocusKey,
@@ -1119,6 +1123,7 @@ class SpatialNavigationService {
       onUpdateHasFocusedChild,
       saveLastFocusedChild,
       trackChildren,
+      trackFocused,
       preferredChildFocusKey,
       focusable,
       isFocusBoundary,
@@ -1215,7 +1220,9 @@ class SpatialNavigationService {
 
       this.saveLastFocusedChildKey(parentComponent, this.focusKey);
 
-      oldComponent.onUpdateFocus(false);
+      if (oldComponent.trackFocused) {
+        oldComponent.onUpdateFocus(false);
+      }
       oldComponent.onBlur(
         this.getNodeLayoutByFocusKey(this.focusKey),
         focusDetails
@@ -1227,7 +1234,9 @@ class SpatialNavigationService {
     if (this.isFocusableComponent(this.focusKey)) {
       const newComponent = this.focusableComponents[this.focusKey];
 
-      newComponent.onUpdateFocus(true);
+      if (newComponent.trackFocused) {
+        newComponent.onUpdateFocus(true);
+      }
       newComponent.onFocus(
         this.getNodeLayoutByFocusKey(this.focusKey),
         focusDetails

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -46,6 +46,7 @@ export interface UseFocusableConfig<P = object> {
   focusable?: boolean;
   saveLastFocusedChild?: boolean;
   trackChildren?: boolean;
+  trackFocused?: boolean;
   autoRestoreFocus?: boolean;
   isFocusBoundary?: boolean;
   focusKey?: string;
@@ -76,6 +77,7 @@ const useFocusableHook = <P>({
   focusable = true,
   saveLastFocusedChild = true,
   trackChildren = false,
+  trackFocused = true,
   autoRestoreFocus = true,
   isFocusBoundary = false,
   focusKey: propFocusKey,
@@ -158,6 +160,7 @@ const useFocusableHook = <P>({
         setHasFocusedChild(isFocused),
       saveLastFocusedChild,
       trackChildren,
+      trackFocused,
       isFocusBoundary,
       autoRestoreFocus,
       focusable
@@ -177,6 +180,8 @@ const useFocusableHook = <P>({
       node,
       preferredChildFocusKey,
       focusable,
+      trackChildren,
+      trackFocused,
       isFocusBoundary,
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
@@ -188,6 +193,8 @@ const useFocusableHook = <P>({
     focusKey,
     preferredChildFocusKey,
     focusable,
+    trackChildren,
+    trackFocused,
     isFocusBoundary,
     onEnterPressHandler,
     onEnterReleaseHandler,


### PR DESCRIPTION
to avoid `<FocusContext.Provider>` re-renders when it doesn’t depend on `focused` state