### PR TITLE
Fixing hasFocusableChild property

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -1184,6 +1184,19 @@ class SpatialNavigationService {
     if (focusKey === this.focusKey) {
       this.setFocus(focusKey);
     }
+
+    /**
+     * Parent nodes are created after children, and child may focus itself.
+     * If so, it's required to check if parent lies on a path to focused child.
+     */
+    let currentComponent = this.focusableComponents[this.focusKey];
+    while (currentComponent) {
+      if (currentComponent.parentFocusKey === focusKey) {
+        this.updateParentsHasFocusedChild(this.focusKey, {});
+        break;
+      }
+      currentComponent = this.focusableComponents[currentComponent.parentFocusKey];
+    }
   }
 
   removeFocusable({ focusKey }: FocusableComponentRemovePayload) {


### PR DESCRIPTION
Parent nodes are created (added to `focusableComponents`) later than its children. This is how `useEffect` works.

It may happen that created child focuses itself. If so, the parent node, when created, has to check whether it lies on a path to focused child or not. If so, created node state (`hasFocusableChild`) and `parentsHavingFocusedChild` property needs to be updated properly.

Currently `hasFocusableChild` is updated properly when all nodes are created and navigation happened. Video below shows:
* App reloads - all nodes are recreated, node `r22` calls focusSelf
* Right key press - focus moved for `r23`, `hasFocusableChild` updated, containers get aqua border (which means `hasFocusableChild` is true)

https://github.com/NoriginMedia/Norigin-Spatial-Navigation/assets/13609312/fef73431-b781-40ce-bedb-8955338ed417


