### PR TITLE
Fixing lastFocusedChildKey property

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -983,9 +983,6 @@ class SpatialNavigationService {
         this.setFocus(nextComponent.focusKey, focusDetails);
       } else {
         const parentComponent = this.focusableComponents[parentFocusKey];
-
-        this.saveLastFocusedChildKey(parentComponent, focusKey);
-
         if (!parentComponent || !parentComponent.isFocusBoundary) {
           this.smartNavigate(direction, parentFocusKey, focusDetails);
         }
@@ -1249,11 +1246,6 @@ class SpatialNavigationService {
       newFocusKey !== this.focusKey
     ) {
       const oldComponent = this.focusableComponents[this.focusKey];
-      const parentComponent =
-        this.focusableComponents[oldComponent.parentFocusKey];
-
-      this.saveLastFocusedChildKey(parentComponent, this.focusKey);
-
       oldComponent.onUpdateFocus(false);
       oldComponent.onBlur(
         this.getNodeLayoutByFocusKey(this.focusKey),
@@ -1424,14 +1416,13 @@ class SpatialNavigationService {
 
     this.log('setFocus', 'focusKey', focusKey);
 
-    const lastFocusedKey = this.focusKey;
     const newFocusKey = this.getNextFocusKey(focusKey);
 
     this.log('setFocus', 'newFocusKey', newFocusKey);
 
     this.setCurrentFocusedKey(newFocusKey, focusDetails);
     this.updateParentsHasFocusedChild(newFocusKey, focusDetails);
-    this.updateParentsLastFocusedChild(lastFocusedKey);
+    this.updateParentsLastFocusedChild(newFocusKey);
   }
 
   updateAllLayouts() {


### PR DESCRIPTION
`lastFocusedChildKey` property needs to be updated when container gets focused, not lazily, when blurred.  

Video below shows:
* App reloads - all nodes are recreated, node `r22` calls focusSelf
* Right key press - focus moved for `r23`, `lastFocusedChildKey` updated to `r22`
* `setFocus("r2")` - focusing parent container, previously focused child (`r22`) was focused, expectation is to keep focus on currently focused child when focusing container.

https://github.com/NoriginMedia/Norigin-Spatial-Navigation/assets/13609312/fa0d5d20-4ef0-4e21-950b-3f33d0b4bce3