### PR TITLE
Fixing lastFocusedChildKey for newly added parents

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -1190,6 +1190,7 @@ class SpatialNavigationService {
     while (currentComponent) {
       if (currentComponent.parentFocusKey === focusKey) {
         this.updateParentsHasFocusedChild(this.focusKey, {});
+        this.updateParentsLastFocusedChild(this.focusKey);
         break;
       }
       currentComponent =


### PR DESCRIPTION
`lastFocusedChildKey` property needs to be updated for newly added parent containers. It's a continuation of #86 fix.

Video below shows:
* Focused `r22`
* `setFocus("r")` - focusing one of the parent containers (not the nearest one)
* `r00` got focused, but expectation is to keep focus on `r22`

https://github.com/NoriginMedia/Norigin-Spatial-Navigation/assets/13609312/052b29e7-b754-4387-a1f9-9fcf785c63f7

