### PR TITLE
Feature: focusBoundaryDirections

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,16 @@ function Menu() {
 Sometimes you don't want the focus to leave your component, for example when displaying a Popup, you don't want the focus to go to
 a component underneath the Popup. This can be enabled with `isFocusBoundary` flag passed to the `useFocusable` hook.
 
+Additionally `focusBoundaryDirections` array can be provided to restrict focus movement only in specific directions.
+That might be useful when defining focus container for menu bar. Please note, that `focusBoundaryDirections` requires
+`isFocusBoundary` to be set to `true`.
+
 ```jsx
 import React, { useEffect } from 'react';
 import { useFocusable, FocusContext } from '@noriginmedia/norigin-spatial-navigation';
 
 function Popup() {
-  const { ref, focusKey, focusSelf } = useFocusable({isFocusBoundary: true});
+  const { ref, focusKey, focusSelf } = useFocusable({isFocusBoundary: true, focusBoundaryDirections: ['up', 'down']});
 
   useEffect(() => {
     focusSelf();
@@ -326,6 +330,11 @@ flag to `false`.
 This flag makes the Focusable Container keep the focus inside its boundaries. It will only block the focus from leaving
 the Container via directional navigation. You can still set the focus manually anywhere via `setFocus`.
 Useful when i.e. you have a modal Popup and you don't want the focus to leave it.
+
+##### `focusBoundaryDirections` (optional)
+This flag sets in which directions focus is blocked from leaving Focusable Container via directional navigation.
+It accepts an array containing `left`, `right`, `up` and/or `down` values. If not specified, all directions are blocked.
+It requires `isFocusBoundary` to be enabled to take effect.
 
 ##### `focusKey` (optional)
 If you want your component to have a persistent focus key, it can be set via this property. Otherwise, it will be auto generated.

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -75,6 +75,7 @@ interface FocusableComponent {
   preferredChildFocusKey?: string;
   focusable: boolean;
   isFocusBoundary: boolean;
+  focusBoundaryDirections?: string[];
   autoRestoreFocus: boolean;
   lastFocusedChildKey?: string;
   layout?: FocusableComponentLayout;
@@ -86,6 +87,7 @@ interface FocusableComponentUpdatePayload {
   preferredChildFocusKey?: string;
   focusable: boolean;
   isFocusBoundary: boolean;
+  focusBoundaryDirections?: string[];
   onEnterPress: (details?: KeyPressDetails) => void;
   onEnterRelease: () => void;
   onArrowPress: (direction: string, details: KeyPressDetails) => boolean;
@@ -983,7 +985,12 @@ class SpatialNavigationService {
         this.setFocus(nextComponent.focusKey, focusDetails);
       } else {
         const parentComponent = this.focusableComponents[parentFocusKey];
-        if (!parentComponent || !parentComponent.isFocusBoundary) {
+
+        const focusBoundaryDirections = parentComponent?.isFocusBoundary
+          ? parentComponent.focusBoundaryDirections || [direction]
+          : [];
+
+        if (!parentComponent || !focusBoundaryDirections.includes(direction)) {
           this.smartNavigate(direction, parentFocusKey, focusDetails);
         }
       }
@@ -1127,7 +1134,8 @@ class SpatialNavigationService {
     preferredChildFocusKey,
     autoRestoreFocus,
     focusable,
-    isFocusBoundary
+    isFocusBoundary,
+    focusBoundaryDirections
   }: FocusableComponent) {
     this.focusableComponents[focusKey] = {
       focusKey,
@@ -1145,6 +1153,7 @@ class SpatialNavigationService {
       preferredChildFocusKey,
       focusable,
       isFocusBoundary,
+      focusBoundaryDirections,
       autoRestoreFocus,
       lastFocusedChildKey: null,
       layout: {
@@ -1488,6 +1497,7 @@ class SpatialNavigationService {
       preferredChildFocusKey,
       focusable,
       isFocusBoundary,
+      focusBoundaryDirections,
       onEnterPress,
       onEnterRelease,
       onArrowPress,
@@ -1505,6 +1515,7 @@ class SpatialNavigationService {
       component.preferredChildFocusKey = preferredChildFocusKey;
       component.focusable = focusable;
       component.isFocusBoundary = isFocusBoundary;
+      component.focusBoundaryDirections = focusBoundaryDirections;
       component.onEnterPress = onEnterPress;
       component.onEnterRelease = onEnterRelease;
       component.onArrowPress = onArrowPress;

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -47,6 +47,7 @@ export interface UseFocusableConfig<P = object> {
   trackChildren?: boolean;
   autoRestoreFocus?: boolean;
   isFocusBoundary?: boolean;
+  focusBoundaryDirections?: string[];
   focusKey?: string;
   preferredChildFocusKey?: string;
   onEnterPress?: EnterPressHandler<P>;
@@ -77,6 +78,7 @@ const useFocusableHook = <P>({
   trackChildren = false,
   autoRestoreFocus = true,
   isFocusBoundary = false,
+  focusBoundaryDirections,
   focusKey: propFocusKey,
   preferredChildFocusKey,
   onEnterPress = noop,
@@ -158,6 +160,7 @@ const useFocusableHook = <P>({
       saveLastFocusedChild,
       trackChildren,
       isFocusBoundary,
+      focusBoundaryDirections,
       autoRestoreFocus,
       focusable
     });
@@ -177,6 +180,7 @@ const useFocusableHook = <P>({
       preferredChildFocusKey,
       focusable,
       isFocusBoundary,
+      focusBoundaryDirections,
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
       onArrowPress: onArrowPressHandler,
@@ -188,6 +192,7 @@ const useFocusableHook = <P>({
     preferredChildFocusKey,
     focusable,
     isFocusBoundary,
+    focusBoundaryDirections,
     onEnterPressHandler,
     onEnterReleaseHandler,
     onArrowPressHandler,


### PR DESCRIPTION
New feature that allows setting focus boundaries in specific directions only.
This is the implementation mentioned in #81.

Video below shows:
* possibility of navigating out of `r2` container
* setting `isFocusBoundary=true` for `r2` container
* navigating in all directions to show that it is not possible to jump out of `r2`
* setting `focusBoundaryDirections=['left', 'up']` for `r2`
* navigating in all directions to show that it's not possible to jump out of `r2` but only when navigating `up` or `left`
* setting `isFocusBoundary=false` for `r2`
* navigating in all directions to show that there's no boundaries even if `focusBoundaryDirections` are still set

https://github.com/NoriginMedia/Norigin-Spatial-Navigation/assets/13609312/ebbdc41b-d7be-4538-ac0c-f498fd46dcaa

