### PR TITLE
Restore lost focus via directional navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,14 @@ By default, when the currently focused component is unmounted (deleted), navigat
 on the nearest available sibling of that component. If this behavior is undesirable, you can disable it by setting this
 flag to `false`.
 
+##### `forceFocus` (default: false)
+This flag makes the Focusable Container force-focusable. When there's more than one force-focusable component,
+the closest to the top left viewport corner (0,0) is force-focused. Such containers can be force-focused when there's
+no currently focused component (or `focusKey` points to not existing component) when navigating with arrows.
+Also, when `focusKey` provided to `setFocus` is not defined or equal to `ROOT_FOCUS_KEY`.
+In other words, if focus is lost, it can be restored to one of force-focusable components by navigating with arrows
+or by focusing `ROOT_FOCUS_KEY`.
+
 ##### `isFocusBoundary` (default: false)
 This flag makes the Focusable Container keep the focus inside its boundaries. It will only block the focus from leaving
 the Container via directional navigation. You can still set the focus manually anywhere via `setFocus`.
@@ -382,7 +390,9 @@ Method to set the focus on the current component. I.e. to set the focus to the P
 the Popup component when it is displayed.
 
 ##### `setFocus` (function) `(focusKey: string) => void`
-Method to manually set the focus to a component providing its `focusKey`.
+Method to manually set the focus to a component providing its `focusKey`. If `focusKey` is not provided or
+is equal to `ROOT_FOCUS_KEY`, an attempt of focusing one of the force-focusable components is made.
+See `useFocusable` hook  [`forceFocus`](#forcefocus-default-false) parameter for more details.
 
 ##### `focused` (boolean)
 Flag that indicates that the current component is focused.

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -46,6 +46,7 @@ export interface UseFocusableConfig<P = object> {
   saveLastFocusedChild?: boolean;
   trackChildren?: boolean;
   autoRestoreFocus?: boolean;
+  forceFocus?: boolean;
   isFocusBoundary?: boolean;
   focusKey?: string;
   preferredChildFocusKey?: string;
@@ -76,6 +77,7 @@ const useFocusableHook = <P>({
   saveLastFocusedChild = true,
   trackChildren = false,
   autoRestoreFocus = true,
+  forceFocus = false,
   isFocusBoundary = false,
   focusKey: propFocusKey,
   preferredChildFocusKey,
@@ -159,6 +161,7 @@ const useFocusableHook = <P>({
       trackChildren,
       isFocusBoundary,
       autoRestoreFocus,
+      forceFocus,
       focusable
     });
 


### PR DESCRIPTION
Feature, that allows defining focusable containers as the one, to which focus can be restored in case it is lost 😅.

`useFocusable` provides `forceFocus` property which when set to `true` makes container force-focusable. If there's more than one of such containers, then the closest to top left viewport corner (0,0) is focused.

It may happen that when navigating with arrows currently focused component is not found. This can be because there was no focused element yet, or current `focusKey` points to non existing element. In such case `smartNavigate` does nothing. From user perspective, the focus is lost and the only way to restore it is to restart the app. `forceFocus` flag address that problem allowing to move focus to one of force-focusable components in that case.

This feature also improves the way how `setFocus` works. It is possible to call `setFocus` without `focusKey` or with `focusKey` equal to `SN:ROOT` (value of `ROOT_FOCUS_KEY` constant). In such case focus will be moved to the force-focusable container closest to the top left viewport corner (same as for directional navigation).

Video below presents feature in action:

https://github.com/NoriginMedia/Norigin-Spatial-Navigation/assets/13609312/dde3035f-6631-4a46-b637-29c77f13ef3a


