### PR TITLE
Focusable container agnostic methods available as top level exports + doesFocusableExist

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ It is useful when you first open the page, or i.e. when your modal Popup gets mo
 
 ```jsx
 import React, { useEffect } from 'react';
-import { useFocusable, FocusContext } from '@noriginmedia/norigin-spatial-navigation';
+import { useFocusable, FocusContext, setFocus } from '@noriginmedia/norigin-spatial-navigation';
 
 function Popup() {
-  const { ref, focusKey, focusSelf, setFocus } = useFocusable();
+  const { ref, focusKey, focusSelf } = useFocusable();
 
   // Focusing self will focus the Popup, which will pass the focus down to the first Child (ButtonPrimary)
   // Alternatively you can manually focus any other component by its 'focusKey'
@@ -293,6 +293,29 @@ setThrottle({
 ### `destroy`
 Resets all the settings and the storage of focusable components. Disables the navigation service.
 
+### `doesFocusableExist` (function) `(focusKey: string) => boolean`
+Returns `true` if Focusable Container with given `focusKey` is created, `false` otherwise.
+
+### `setFocus` (function) `(focusKey: string) => void`
+Method to manually set the focus to a component providing its `focusKey`.
+
+### `getCurrentFocusKey` (function) `() => string`
+Returns the currently focused component's focus key.
+
+### `navigateByDirection` (function) `(direction: string, focusDetails: FocusDetails) => void`
+Method to manually navigation to a certain direction. I.e. you can assign a mouse-wheel to navigate Up and Down.
+Also useful when you have some "Arrow-like" UI in the app that is meant to navigate in certain direction when pressed
+with the mouse or a "magic remote" on some TVs.
+
+### `pause` (function)
+Pauses all the key event handlers.
+
+### `resume` (function)
+Resumes all the key event handlers.
+
+### `updateAllLayouts` (function)
+Manually recalculate all the layouts. Rarely used.
+
 ### `useFocusable` hook
 This hook is the main link between the React component (its DOM element) and the navigation service.
 It is used to register the component in the service, get its `focusKey`, `focused` state etc.
@@ -381,9 +404,6 @@ function Button() {
 Method to set the focus on the current component. I.e. to set the focus to the Page (Container) when it is mounted, or
 the Popup component when it is displayed.
 
-##### `setFocus` (function) `(focusKey: string) => void`
-Method to manually set the focus to a component providing its `focusKey`.
-
 ##### `focused` (boolean)
 Flag that indicates that the current component is focused.
 
@@ -394,23 +414,6 @@ Only works when `trackChildren` is enabled!
 ##### `focusKey` (string)
 String that contains the focus key for the component. It is either the same as `focusKey` passed to the hook params,
 or an automatically generated one.
-
-#### `getCurrentFocusKey` (function) `() => string`
-Returns the currently focused component's focus key.
-
-##### `navigateByDirection` (function) `(direction: string, focusDetails: FocusDetails) => void`
-Method to manually navigation to a certain direction. I.e. you can assign a mouse-wheel to navigate Up and Down.
-Also useful when you have some "Arrow-like" UI in the app that is meant to navigate in certain direction when pressed
-with the mouse or a "magic remote" on some TVs.
-
-##### `pause` (function)
-Pauses all the key event handlers.
-
-##### `resume` (function)
-Resumes all the key event handlers.
-
-##### `updateAllLayouts` (function)
-Manually recalculate all the layouts. Rarely used.
 
 ### `FocusContext` (required for Focusable Containers)
 Used to provide the `focusKey` of the current Focusable Container down the Tree to the next child level. [See Example](#wrapping-leaf-components-with-a-focusable-container)

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -558,6 +558,7 @@ class SpatialNavigationService {
     this.destroy = this.destroy.bind(this);
     this.setKeyMap = this.setKeyMap.bind(this);
     this.getCurrentFocusKey = this.getCurrentFocusKey.bind(this);
+    this.doesFocusableExist = this.doesFocusableExist.bind(this);
 
     this.setFocusDebounced = debounce(this.setFocus, AUTO_RESTORE_FOCUS_DELAY, {
       leading: false,
@@ -823,7 +824,7 @@ class SpatialNavigationService {
    * navigateByDirection('right') // The focus is moved to right
    */
   navigateByDirection(direction: string, focusDetails: FocusDetails) {
-    if (this.paused === true || this.nativeMode) {
+    if (this.paused === true || !this.enabled || this.nativeMode) {
       return;
     }
 
@@ -1437,7 +1438,7 @@ class SpatialNavigationService {
     // Cancel any pending auto-restore focus calls if we are setting focus manually
     this.setFocusDebounced.cancel();
 
-    if (!this.enabled) {
+    if (!this.enabled || this.nativeMode) {
       return;
     }
 
@@ -1453,7 +1454,7 @@ class SpatialNavigationService {
   }
 
   updateAllLayouts() {
-    if (this.nativeMode) {
+    if (!this.enabled || this.nativeMode) {
       return;
     }
 
@@ -1520,6 +1521,10 @@ class SpatialNavigationService {
   isNativeMode() {
     return this.nativeMode;
   }
+
+  doesFocusableExist(focusKey: string) {
+    return !!this.focusableComponents[focusKey];
+  }
 }
 
 /**
@@ -1528,4 +1533,16 @@ class SpatialNavigationService {
 /** @internal */
 export const SpatialNavigation = new SpatialNavigationService();
 
-export const { init, setThrottle, destroy, setKeyMap } = SpatialNavigation;
+export const {
+  init,
+  setThrottle,
+  destroy,
+  setKeyMap,
+  setFocus,
+  navigateByDirection,
+  pause,
+  resume,
+  updateAllLayouts,
+  getCurrentFocusKey,
+  doesFocusableExist
+} = SpatialNavigation;

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -63,12 +63,6 @@ export interface UseFocusableResult {
   focused: boolean;
   hasFocusedChild: boolean;
   focusKey: string;
-  setFocus: (focusKey: string, focusDetails?: FocusDetails) => void;
-  navigateByDirection: (direction: string, focusDetails: FocusDetails) => void;
-  pause: () => void;
-  resume: () => void;
-  updateAllLayouts: () => void;
-  getCurrentFocusKey: () => string;
 }
 
 const useFocusableHook = <P>({
@@ -200,15 +194,7 @@ const useFocusableHook = <P>({
     focusSelf,
     focused,
     hasFocusedChild,
-    focusKey, // returns either the same focusKey as passed in, or generated one
-    setFocus: SpatialNavigation.isNativeMode()
-      ? noop
-      : SpatialNavigation.setFocus,
-    navigateByDirection: SpatialNavigation.navigateByDirection,
-    pause: SpatialNavigation.pause,
-    resume: SpatialNavigation.resume,
-    updateAllLayouts: SpatialNavigation.updateAllLayouts,
-    getCurrentFocusKey: SpatialNavigation.getCurrentFocusKey
+    focusKey // returns either the same focusKey as passed in, or generated one
   };
 };
 


### PR DESCRIPTION
!! Breaking change !!

To use `setFocus`, `getCurrentFocusKey`, `navigateByDirection`, `pause`, `resume`, `updateAllLayouts` methods it is required to create new focusable component. Such component is usually useless and gives nothing to the overall navigation. Moreover, react component has few more state variables defined that just take resources.

Mentioned methods are working fine outside the context of the Focusable Container, so it's better to have them available as top level exports.

If you would like to keep backward compatibility, `useFocusableHook` can still return them, but I think cleaner way is to just move those methods and bump proper version number.

PR adds also one more, very handy method: `doesFocusableExist`. Sometimes, when restoring screen state, it's crucial to know if element we want to focus still exists or not. Such check allows avoiding unintentional focus loss.