### PR TITLE
Add support for RTL

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,5 +7,8 @@
   ],
   "parserOptions": {
     "project": "./tsconfig.json"
+  },
+  "rules": {
+    "no-nested-ternary": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ Also consider `role` and `aria-label` attributes. But that depends on the applic
 
 The flag is ignored if `nativeMode` is set.
 
+##### `rtl`: boolean (default: false)
+This flag changes focus behavior for layouts in right-to-left (RTL) languages such as Arabic and Hebrew.
+
 ### `setKeyMap`
 Method to set custom key codes. I.e. when the device key codes differ from a standard browser arrow key codes.
 ```jsx
@@ -421,6 +424,8 @@ Used to provide the `focusKey` of the current Focusable Container down the Tree 
 interface FocusableComponentLayout {
   left: number; // absolute coordinate on the screen
   top: number; // absolute coordinate on the screen
+  readonly right: number; // absolute coordinate on the screen
+  readonly bottom: number; // absolute coordinate on the screen
   width: number;
   height: number;
   x: number; // relative to the parent DOM element

--- a/src/VisualDebugger.ts
+++ b/src/VisualDebugger.ts
@@ -1,3 +1,5 @@
+import WritingDirection from "./WritingDirection";
+
 // We'll make VisualDebugger no-op for any environments lacking a DOM (e.g. SSR and React Native non-web platforms).
 const hasDOM = typeof window !== 'undefined' && window.document;
 
@@ -7,6 +9,8 @@ const HEIGHT = hasDOM ? window.innerHeight : 0;
 interface NodeLayout {
   left: number;
   top: number;
+  readonly right: number;
+  readonly bottom: number;
   width: number;
   height: number;
 }
@@ -16,18 +20,22 @@ class VisualDebugger {
 
   private layoutsCtx: CanvasRenderingContext2D;
 
-  constructor() {
+  private writingDirection: WritingDirection;
+
+  constructor(writingDirection: WritingDirection) {
     if (hasDOM) {
-      this.debugCtx = VisualDebugger.createCanvas('sn-debug', '1010');
-      this.layoutsCtx = VisualDebugger.createCanvas('sn-layouts', '1000');
+      this.debugCtx = VisualDebugger.createCanvas('sn-debug', '1010', writingDirection);
+      this.layoutsCtx = VisualDebugger.createCanvas('sn-layouts', '1000', writingDirection);
+      this.writingDirection = writingDirection;
     }
   }
 
-  static createCanvas(id: string, zIndex: string) {
+  static createCanvas(id: string, zIndex: string, writingDirection: WritingDirection) {
     const canvas: HTMLCanvasElement =
       document.querySelector(`#${id}`) || document.createElement('canvas');
 
     canvas.setAttribute('id', id);
+    canvas.setAttribute('dir', writingDirection === WritingDirection.LTR ? "ltr" : "rtl");
 
     const ctx = canvas.getContext('2d');
 
@@ -73,16 +81,20 @@ class VisualDebugger {
     );
     this.layoutsCtx.font = '8px monospace';
     this.layoutsCtx.fillStyle = 'red';
-    this.layoutsCtx.fillText(focusKey, layout.left, layout.top + 10);
-    this.layoutsCtx.fillText(parentFocusKey, layout.left, layout.top + 25);
+
+    const horizontalStartDirection = this.writingDirection === WritingDirection.LTR ? "left" : "right";
+    const horizontalStartCoordinate = layout[horizontalStartDirection];
+
+    this.layoutsCtx.fillText(focusKey, horizontalStartCoordinate, layout.top + 10);
+    this.layoutsCtx.fillText(parentFocusKey, horizontalStartCoordinate, layout.top + 25);
     this.layoutsCtx.fillText(
-      `left: ${layout.left}`,
-      layout.left,
+      `${horizontalStartDirection}: ${horizontalStartCoordinate}`,
+      horizontalStartCoordinate,
       layout.top + 40
     );
     this.layoutsCtx.fillText(
       `top: ${layout.top}`,
-      layout.left,
+      horizontalStartCoordinate,
       layout.top + 55
     );
   }

--- a/src/WritingDirection.ts
+++ b/src/WritingDirection.ts
@@ -1,0 +1,6 @@
+enum WritingDirection {
+  LTR,
+  RTL
+};
+
+export default WritingDirection;

--- a/src/measureLayout.ts
+++ b/src/measureLayout.ts
@@ -36,11 +36,26 @@ const measureLayout = (node: HTMLElement) => {
       width,
       height,
       left,
-      top
+      top,
+      get right() {
+        return this.left + this.width;
+      },
+      get bottom() {
+        return this.top + this.height;
+      }
     };
   }
 
-  return { x: 0, y: 0, width: 0, height: 0, left: 0, top: 0 };
+  return { 
+    x: 0, 
+    y: 0, 
+    width: 0, 
+    height: 0, 
+    left: 0, 
+    top: 0, 
+    right: 0,
+    bottom: 0,
+  };
 };
 
 export default measureLayout;
@@ -55,9 +70,24 @@ export const getBoundingClientRect = (node: HTMLElement) => {
       width: rect.width,
       height: rect.height,
       left: rect.left,
-      top: rect.top
+      top: rect.top,
+      get right() {
+        return this.left + this.width;
+      },
+      get bottom() {
+        return this.top + this.height;
+      }
     };
   }
 
-  return { x: 0, y: 0, width: 0, height: 0, left: 0, top: 0 };
+  return { 
+    x: 0,
+    y: 0, 
+    width: 0,
+    height: 0, 
+    left: 0, 
+    top: 0,
+    right: 0,
+    bottom: 0,
+  };
 };


### PR DESCRIPTION
This PR adds support for RTL and addresses issue #88. Feel free to request changes, overwrite, or ignore and close this PR. The PR is provided as a courtesy. 

Here is a summary of the changes:
- Adds `rtl` flag to `init` function
- Adds enum `WritingDirection`
- Adds properties `right` & `bottom` to `FocusableComponentLayout`
- Refactors `getChildClosestToOrigin` to support search from the top right corner of the viewport based on writing direction
- Refactors code depending on `isIncrementalDirection` to support RTL
- Refactors code to use `right`/`bottom`
- Adds support for `rtl` in the `VisualDebugger`

Notes:
- I've removed the `no-nested-ternary` eslint rule as it's useful for concisely defining cases. 
- The main logical change in this PR is to `getChildClosestToOrigin`. All of the other changes should preserve logic in either writing direction. The changes to the other functions are primarily to preserve the meaning of the variable `isIncrementalDirection`. In other words, the booleans `isVertical` and `isIncrementalDirection` together map to `left`, `up`, `right`, `down`. However, with RTL support, `isVertical`, `isIncrementalDirection`, and `writingDirection` is needed to map to the same directions. These functions could be rewritten to use the direction directly so that logic is identical regardless of writing direction.