### PR TITLE
Fixing focus restoration for added children

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -1227,7 +1227,7 @@ class SpatialNavigationService {
      * If for some reason this component was already focused before it was added, call the update
      */
     if (focusKey === this.focusKey) {
-      this.setFocus(focusKey);
+      this.setFocus(preferredChildFocusKey || focusKey);
     }
 
     /**


### PR DESCRIPTION
Issue: Focus is not properly restored to `preferredChildFocusKey` when focusable is created.

It may happen that focusable element that should be focused is created later that focus to it is set. In such case `addFocusable` restores focus when it finds that just adding element should be focused. Such restoration should take into consideration the fact, that added focusable may be treated just as a container and is designed to move focus to its preferred child (which, again, might not be created yet). This is to make `setFocus` behavior consistent with situation when executed having all elements fully rendered.

Video below shows:
* Enter pressed on `r00` which sets focus to `r1` and loads components on the right (including `r1`). `r1` has `preferredChildFocusKey` set to `r15`.
* red border indicates, that `r1` keep focus while it should be moved to `r15`.
* as a next test, down/up test is done to show that by default always leaf is focused (in our case preferred child: `r15`)
* another test, shows that, when all elements are rendered, manually executed `setFocus('r1')` (see panel on the right) focuses `r15`.

https://github.com/NoriginMedia/Norigin-Spatial-Navigation/assets/13609312/4a9db099-2256-4249-b5ec-38d7ac919324


Expected behavior - `r15` focused on pressing enter on `r00`:

https://github.com/NoriginMedia/Norigin-Spatial-Navigation/assets/13609312/52231d8c-45d4-4080-af5c-eab492f42470
