### PR TITLE
Include event key in case there is no code available

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -673,7 +673,7 @@ class SpatialNavigationService {
   }
 
   static getKeyCode(event: KeyboardEvent) {
-    return event.keyCode || event.code;
+    return event.keyCode || event.code || event.key;
   }
 
   bindEventHandlers() {


### PR DESCRIPTION
As suggested by #121, include `event.key` for devices that don't support `event.code`.