### PR TITLE
On Click Event Implement

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -767,6 +767,35 @@ class SpatialNavigationService {
     }
   }
 
+  onClickHandler(focusKey: string) {
+    if (!focusKey) {
+      this.log('onClickHandler', 'noFocusKey');
+      return;
+    }
+
+    const component = this.focusableComponents[focusKey];
+
+    if (!component) {
+      this.log('onClickHandler', 'noComponent');
+
+      return;
+    }
+
+    // Set focus as if this were a key press
+    this.setFocus(focusKey);
+
+    // Call onEnterPress directly or via existing mechanisms that handle enter press
+    if (component.onEnterPress) {
+      const keysDetails = {
+        pressedKeys: {
+          click: 1
+        }
+      };
+
+      component.onEnterPress(keysDetails);
+    }
+  }
+
   unbindEventHandlers() {
     // We check both because the React Native remote debugger implements window, but not window.removeEventListener.
     if (typeof window !== 'undefined' && window.removeEventListener) {
@@ -1283,6 +1312,12 @@ class SpatialNavigationService {
      * If so, it's required to check if parent lies on a path to focused child.
      */
     let currentComponent = this.focusableComponents[this.focusKey];
+
+    if (node) {
+      node.removeEventListener('click', () => this.onClickHandler(focusKey));
+      node.addEventListener('click', () => this.onClickHandler(focusKey));
+    }
+
     while (currentComponent) {
       if (currentComponent.parentFocusKey === focusKey) {
         this.updateParentsHasFocusedChild(this.focusKey, {});


### PR DESCRIPTION
I am a Smart TV lead developer at Toffee the largest OTT in Bangladesh. I am using @noriginmedia/norigin-spatial-navigation in my react project. My application was already published in Samsung but WebOS (LG) was rejected due to some mouse navigation issues. 

WebOS requirement:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/farid/AppData/Local/Packages/oice_16_974fa576_32c1d314_30ce/AC/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/farid/AppData/Local/Packages/oice_16_974fa576_32c1d314_30ce/AC/Temp/msohtmlclip1/01/clip_filelist.xml">
</head>

<body link="#0563C1" vlink="#954F72">


27 | P2 | 1.5. Remote   Control | Magic remote   Control | - | Execute app → Navigate and execute functions of   app using Magic remote control | Check if it   supports magic remote control     ※ Check entire remote   control Key >Check defined operation by Key     ※ Check if App goes   back to the previous status after the operation of the Key. | ※ Magic Remote Control support is   required
-- | -- | -- | -- | -- | -- | -- | --
28 | P2 | 1.5. Remote   Control | MMRC/Pointer | - | Execute  app → Move Magic remote   control screen cursor (pointer) in app screen | Cursor  moves properly in accordance with Magic remote control movement |  
29 | P2 | 1.5. Remote   Control | MMRC/OK   Key | - | Execute  app → Use Magic remote control   → Put pointer over on   UI Button → Input OK   Key | App  moves properly when putting Magic remote control pointer over the UI button   and press OK key |  
30 | P2 | 1.5. Remote   Control | MMRC/Wheel | Wheel  function is supported | Execute  app → Use Magic remote control   wheel on Page/List scroll contents          [CASE]     1. Check upper/lower, left/right movrment      2. If map is included, check zoom in/out function | Magic   remote control wheel works properly in page/list scroll contents |  

</body>

</html>

WebOS has two types of remote one MRCU and TRCU. So in MRCU have a mouse pointer with click, scroll, etc events. in your package, there is no click event available only enter is working. I want to add this click event to your package. When I try to implement it in my app I need to control it from my end. That's why I am thinking I adding this event to my package. Because this package is not compatible with LG TV requirements. If anyone uses it they need to configure all the custom events on their end.