### PR TITLE
Feat: Add configurable distance calculation methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [2.2.0]
 ## Added
 - New init config option `distanceCalculationMethod` that allows switching between edge-based, center-based and corner-based (default) distance calculations.
+- Support for a custom distance calculation function via the `customDistanceCalculationFunction` option, enabling custom logic for determining distances between focusable components. This will override the `getSecondaryAxisDistance` method.
+
 
 # [2.1.0]
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.2.0]
+## Added
+- New init config option `distanceCalculationMethod` that allows switching between edge-based, center-based and corner-based (default) distance calculations.
+
 # [2.1.0]
 ## Added
 - new `init` config option `shouldUseNativeEvents` that enables the use of native events for triggering actions, such as clicks or key presses.
-- new `init` config option `rtl` that changes focus behavior for layouts in right-to-left (RTL) languages such as Arabic and Hebrew. 
+- new `init` config option `rtl` that changes focus behavior for layouts in right-to-left (RTL) languages such as Arabic and Hebrew.
 
 # [2.0.2]
 ## Added

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ init({
 ## New Distance Calculation Configuration
 Starting from version `2.2.0`, you can configure the method used for distance calculations between focusable components. This can be set during initialization using the `distanceCalculationMethod` option.
 
-### Available Options
+### How to use | Available Options
 * `edges`:  Calculates distances using the closest edges of the components.
 * `center`:  Calculates distances using the center points of the components for size-agnostic comparisons. Ideal for non-uniform elements between siblings.
 * `corners`: Calculates distances using the corners of the components, between the nearest corners. This is the default value.
@@ -76,6 +76,47 @@ import { init } from '@noriginmedia/norigin-spatial-navigation';
 init({
   // options
   distanceCalculationMethod: 'center', // or 'edges' or 'corners' (default)
+});
+```
+
+## Custom Distance Calculation Function
+In addition to the predefined distance calculation methods, you can define your own custom distance calculation function. This will override the `getSecondaryAxisDistance` method.
+
+You can pass your custom distance calculation function during initialization using the customDistanceCalculationFunction option. This function will override the built-in methods.
+
+### How to use | Available Options
+The custom distance calculation function should follow the DistanceCalculationFunction type signature:
+
+```jsx
+type DistanceCalculationFunction = (
+  refCorners: Corners,
+  siblingCorners: Corners,
+  isVerticalDirection: boolean,
+  distanceCalculationMethod: DistanceCalculationMethod
+) => number;
+```
+
+### Example
+```jsx
+import { init } from '@noriginmedia/norigin-spatial-navigation';
+
+// Define a custom distance calculation function
+const myCustomDistanceCalculationFunction = (refCorners, siblingCorners, isVerticalDirection, distanceCalculationMethod) => {
+  // Custom logic for distance calculation
+  const { a: refA, b: refB } = refCorners;
+  const { a: siblingA, b: siblingB } = siblingCorners;
+  const coordinate = isVerticalDirection ? 'x' : 'y';
+
+  const refCoordinateCenter = (refA[coordinate] + refB[coordinate]) / 2;
+  const siblingCoordinateCenter = (siblingA[coordinate] + siblingB[coordinate]) / 2;
+
+  return Math.abs(refCoordinateCenter - siblingCoordinateCenter);
+};
+
+// Initialize with custom distance calculation function
+init({
+  // options
+  customDistanceCalculationFunction: myCustomDistanceCalculationFunction,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,23 @@ init({
 });
 ```
 
+## New Distance Calculation Configuration
+Starting from version `2.2.0`, you can configure the method used for distance calculations between focusable components. This can be set during initialization using the `distanceCalculationMethod` option.
+
+### Available Options
+* `edges`:  Calculates distances using the closest edges of the components.
+* `center`:  Calculates distances using the center points of the components for size-agnostic comparisons. Ideal for non-uniform elements between siblings.
+* `corners`: Calculates distances using the corners of the components, between the nearest corners. This is the default value.
+
+```jsx
+import { init } from '@noriginmedia/norigin-spatial-navigation';
+
+init({
+  // options
+  distanceCalculationMethod: 'center', // or 'edges' or 'corners' (default)
+});
+```
+
 ## Making your component focusable
 Most commonly you will have Leaf Focusable components. (See [Tree Hierarchy](#tree-hierarchy-of-focusable-components))
 Leaf component is the one that doesn't have focusable children.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "React hooks based Spatial Navigation solution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,8 @@ const logo = require('../logo.png').default;
 
 init({
   debug: false,
-  visualDebug: false
+  visualDebug: false,
+  distanceCalculationMethod: 'center'
 });
 
 const rows = shuffle([
@@ -182,12 +183,15 @@ const AssetWrapper = styled.div`
 `;
 
 interface AssetBoxProps {
+  index: number;
+  isShuffleSize: boolean;
   focused: boolean;
   color: string;
 }
 
 const AssetBox = styled.div<AssetBoxProps>`
-  width: 225px;
+  width: ${({ isShuffleSize, index }) =>
+    isShuffleSize ? `${80 + index * 30}px` : '225px'};
   height: 127px;
   background-color: ${({ color }) => color};
   border-color: white;
@@ -206,6 +210,8 @@ const AssetTitle = styled.div`
 `;
 
 interface AssetProps {
+  index: number;
+  isShuffleSize: boolean;
   title: string;
   color: string;
   onEnterPress: (props: object, details: KeyPressDetails) => void;
@@ -216,7 +222,14 @@ interface AssetProps {
   ) => void;
 }
 
-function Asset({ title, color, onEnterPress, onFocus }: AssetProps) {
+function Asset({
+  title,
+  color,
+  onEnterPress,
+  onFocus,
+  isShuffleSize,
+  index
+}: AssetProps) {
   const { ref, focused } = useFocusable({
     onEnterPress,
     onFocus,
@@ -228,7 +241,12 @@ function Asset({ title, color, onEnterPress, onFocus }: AssetProps) {
 
   return (
     <AssetWrapper ref={ref}>
-      <AssetBox color={color} focused={focused} />
+      <AssetBox
+        index={index}
+        color={color}
+        focused={focused}
+        isShuffleSize={isShuffleSize}
+      />
       <AssetTitle>{title}</AssetTitle>
     </AssetWrapper>
   );
@@ -261,6 +279,7 @@ const ContentRowScrollingContent = styled.div`
 `;
 
 interface ContentRowProps {
+  isShuffleSize: boolean;
   title: string;
   onAssetPress: (props: object, details: KeyPressDetails) => void;
   onFocus: (
@@ -273,7 +292,8 @@ interface ContentRowProps {
 function ContentRow({
   title: rowTitle,
   onAssetPress,
-  onFocus
+  onFocus,
+  isShuffleSize
 }: ContentRowProps) {
   const { ref, focusKey } = useFocusable({
     onFocus
@@ -297,13 +317,14 @@ function ContentRow({
         <ContentRowTitle>{rowTitle}</ContentRowTitle>
         <ContentRowScrollingWrapper ref={scrollingRef}>
           <ContentRowScrollingContent>
-            {assets.map(({ title, color }) => (
+            {assets.map(({ title, color }, index) => (
               <Asset
-                key={title}
+                index={index}
                 title={title}
                 color={color}
                 onEnterPress={onAssetPress}
                 onFocus={onAssetFocus}
+                isShuffleSize={isShuffleSize}
               />
             ))}
           </ContentRowScrollingContent>
@@ -397,12 +418,13 @@ function Content() {
         </SelectedItemWrapper>
         <ScrollingRows ref={ref}>
           <div>
-            {rows.map(({ title }) => (
+            {rows.map(({ title }, index) => (
               <ContentRow
                 key={title}
                 title={title}
                 onAssetPress={onAssetPress}
                 onFocus={onRowFocus}
+                isShuffleSize={index === rows.length - 1} // last row will have assets with random measurements (Width)
               />
             ))}
           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -418,13 +418,13 @@ function Content() {
         </SelectedItemWrapper>
         <ScrollingRows ref={ref}>
           <div>
-            {rows.map(({ title }, index) => (
+            {rows.map(({ title }) => (
               <ContentRow
                 key={title}
                 title={title}
                 onAssetPress={onAssetPress}
                 onFocus={onRowFocus}
-                isShuffleSize={index === rows.length - 1} // last row will have assets with random measurements (Width)
+                isShuffleSize={Math.random() < 0.5} // Rows will have children assets of different sizes, randomly setting it to true or false.
               />
             ))}
           </div>

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -20,6 +20,8 @@ const KEY_ENTER = 'enter';
 
 export type Direction = 'up' | 'down' | 'left' | 'right';
 
+type DistanceCalculationMethod = 'center' | 'edges' | 'corners';
+
 const DEFAULT_KEY_MAP = {
   [DIRECTION_LEFT]: [37, 'ArrowLeft'],
   [DIRECTION_UP]: [38, 'ArrowUp'],
@@ -241,7 +243,7 @@ class SpatialNavigationService {
 
   private writingDirection: WritingDirection;
 
-  private distanceCalculationMethod: string;
+  private distanceCalculationMethod: DistanceCalculationMethod;
 
   /**
    * Used to determine the coordinate that will be used to filter items that are over the "edge"
@@ -617,7 +619,7 @@ class SpatialNavigationService {
     shouldFocusDOMNode = false,
     shouldUseNativeEvents = false,
     rtl = false,
-    distanceCalculationMethod = 'corners'
+    distanceCalculationMethod = 'corners' as DistanceCalculationMethod
   } = {}) {
     if (!this.enabled) {
       this.enabled = true;


### PR DESCRIPTION
Based on the following issue: → [Wrong decision on distance measurement SpatialNavigation.ts :getSecondaryAxisDistance()](https://github.com/NoriginMedia/Norigin-Spatial-Navigation/issues/134
) 

We wanted to improve the way on how we handle the algorithm that takes care of the distance calculation between two elements. 

This implementation allows developers to choose the best method for navigating between focusable elements. Using `corners` is ideal for siblings of the same size, while the `center` method is better suited for siblings of varying sizes. Additionally, the `edges` option provides another method for edge-based distance calculations.

**Quick summary :** 

- Added a new initialization option `distanceCalculationMethod` in the `init` method. This option accepts three values: `center`, `edges`, and `corners`(default).
- Updated the `getSecondaryAxisDistance` method to support different distance calculation methods.

**Usage:** 

```jsx
init({
  debug: false,
  visualDebug: false,
  distanceCalculationMethod: 'center',
  // other options
});

```

Working Demo With Asset sizing modifications : 
`distanceCalculationMethod: 'center'`

https://github.com/user-attachments/assets/acbe3631-b12f-4475-8190-c285806c1279



Feel free to add any improvement or suggestion to this implementation. 