### PR TITLE
feat: add focus options in conjunction with shouldFocusDOMNode

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -189,6 +189,11 @@ class SpatialNavigationService {
    */
   private parentsHavingFocusedChild: string[];
 
+  /**
+   * When shouldFocusDOMNode is true, this prop specifies the focus options that should be passed to the element being focused.
+   */
+  private domNodeFocusOptions: FocusOptions;
+
   private enabled: boolean;
 
   /**
@@ -544,6 +549,7 @@ class SpatialNavigationService {
      */
     this.parentsHavingFocusedChild = [];
 
+    this.domNodeFocusOptions = {};
     this.enabled = false;
     this.nativeMode = false;
     this.throttle = 0;
@@ -596,10 +602,12 @@ class SpatialNavigationService {
     throttleKeypresses = false,
     useGetBoundingClientRect = false,
     shouldFocusDOMNode = false,
+    domNodeFocusOptions = {},
     shouldUseNativeEvents = false,
     rtl = false
   } = {}) {
     if (!this.enabled) {
+      this.domNodeFocusOptions = domNodeFocusOptions;
       this.enabled = true;
       this.nativeMode = nativeMode;
       this.throttleKeypresses = throttleKeypresses;
@@ -1385,7 +1393,7 @@ class SpatialNavigationService {
       const newComponent = this.focusableComponents[this.focusKey];
 
       if (this.shouldFocusDOMNode && newComponent.node) {
-        newComponent.node.focus();
+        newComponent.node.focus(this.domNodeFocusOptions);
       }
 
       newComponent.onUpdateFocus(true);


### PR DESCRIPTION
For applications that handle scrolling on their own, the default behavior of [HTMLElement focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) method interferes and causes the screen to scroll too far, such that the focused element is not on the visible screen.

Toggling the `preventScroll` option of the HTMLElement focus method to `true` stops the default scroll behavior and allows apps to define their own scrolling behavior. I am proposing this can be accomplished by providing a `FocusOptions` prop to `init` that will only be applicable when `shouldFocusDOMNode` is `true`.

If the user doesn't provide a `FocusOptions` object, there will be no affect to the default behavior of spatial navigation.