### PR TITLE
Updated documentation and bumped package version to v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [2.1.1]
 ## Added
-- new `init` config option domNodeFocusOptions for passing [FocusOptions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters) when using `shouldFocusDOMNode`
+- new `init` config option `domNodeFocusOptions` for passing [FocusOptions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters) when using `shouldFocusDOMNode`
 
 # [2.1.0]
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.1.1]
+## Added
+- new `init` config option dom
+
 # [2.1.0]
 ## Added
 - new `init` config option `shouldUseNativeEvents` that enables the use of native events for triggering actions, such as clicks or key presses.
-- new `init` config option `rtl` that changes focus behavior for layouts in right-to-left (RTL) languages such as Arabic and Hebrew. 
+- new `init` config option `rtl` that changes focus behavior for layouts in right-to-left (RTL) languages such as Arabic and Hebrew.
 
 # [2.0.2]
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [2.1.1]
 ## Added
-- new `init` config option dom
+- new `init` config option domNodeFocusOptions for passing [FocusOptions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters) when using `shouldFocusDOMNode`
 
 # [2.1.0]
 ## Added

--- a/README.md
+++ b/README.md
@@ -258,7 +258,12 @@ Note that it is the developer's responsibility to make the elements accessible! 
 as it dives directly into the various html tags and how it complies with accessibility. Non-accessible tags like `<div>` needs to have the [tabindex](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets) attribute set.
 Also consider `role` and `aria-label` attributes. But that depends on the application.
 
-The flag is ignored if `nativeMode` is set.
+[FocusOptions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters) can be set using the `domNodeFocusOptions` option documented below.
+
+This flag is ignored if `nativeMode` is set to `true`.
+
+##### `domNodeFocusOptions`: [FocusOptions](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters) (default: `{}`)
+This object is passed to the `focus` method of the underlying _accessible_ DOM node when `shouldFocusDOMNode` is enabled.
 
 ### `shouldUseNativeEvents`: boolean (default: false)
 This flag, when set to true, enables the use of native events for triggering actions, such as clicks or key presses. For instance, the onClick method will be triggered while pressing the enterKey, as well as cliicking the element itself. It is particularly beneficial for enhancing the accessibility of web applications. When shouldUseNativeEvents is active, the underlying accessible DOM node becomes the focus of the event.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@noriginmedia/norigin-spatial-navigation",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "React hooks based Spatial Navigation solution",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Updated documentation for new `domNodeFocusOptions` option and preparing for its release.

#### Changed
- _README_ updated with new `init` option `domNodeFocusOptions`
- _CHANGELOG_ updated
- Updated package version to `v2.1.1`