### PR TITLE
Updated documentation and bumped package version to v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - New init config option `distanceCalculationMethod` that allows switching between edge-based, center-based and corner-based (default) distance calculations.
 - Support for a custom distance calculation function via the `customDistanceCalculationFunction` option, enabling custom logic for determining distances between focusable components. This will override the `getSecondaryAxisDistance` method.
+- Added `updateRTL` method to update the RTL behavior dynamically. This method allows toggling the Right-to-Left layout at runtime, updating the spatial navigation behavior without requiring reinitialization.
 
 # [2.1.1]
 ## Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noriginmedia/norigin-spatial-navigation",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@noriginmedia/norigin-spatial-navigation",
-      "version": "2.1.1",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"


### PR DESCRIPTION
In the recent PR ([Feat: Add configurable distance calculation methods #138](https://github.com/NoriginMedia/Norigin-Spatial-Navigation/pull/138/files)), we mistakenly updated the package version directly within the feature PR (specifically here: https://github.com/NoriginMedia/Norigin-Spatial-Navigation/pull/138/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519). As a result, the `updateRTL` feature was also included in the same version.

To avoid skipping a version of the `norigin-spatial-navigation` package, we will publish a new npm package version that includes both features in a single release.

This means that v2.2.1 is already bumped, so we only need to add these changes, release and `npm publish` a new version.


If you find a better approach, please, feel free to suggest/add it.