### PR TITLE
Feat/add on arrow release

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,10 @@ Receives `direction` (`left`, `right`, `up`, `down`), `extraProps` (see below) a
 This callback HAS to return `true` if you want to proceed with the default directional navigation behavior, or `false`
 if you want to block the navigation in the specified direction.
 
+##### `onArrowRelease` (function)
+Callback that is called when the component is focused and Arrow key is released.
+Receives `direction` (`left`, `right`, `up`, `down`), `extraProps` (see below) as argument.
+
 ##### `onFocus` (function)
 Callback that is called when component gets focus.
 Receives `FocusableComponentLayout`, `extraProps` and `FocusDetails` as arguments.

--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -157,9 +157,9 @@ const getChildClosestToOrigin = (
   const comparator =
     writingDirection === WritingDirection.LTR
       ? ({ layout }: FocusableComponent) =>
-        Math.abs(layout.left) + Math.abs(layout.top)
+          Math.abs(layout.left) + Math.abs(layout.top)
       : ({ layout }: FocusableComponent) =>
-        Math.abs(window.innerWidth - layout.right) + Math.abs(layout.top);
+          Math.abs(window.innerWidth - layout.right) + Math.abs(layout.top);
 
   const childrenClosestToOrigin = sortBy(children, comparator);
 
@@ -274,22 +274,22 @@ class SpatialNavigationService {
     const itemStart = isVertical
       ? layout.top
       : writingDirection === WritingDirection.LTR
-        ? layout.left
-        : layout.right;
+      ? layout.left
+      : layout.right;
 
     const itemEnd = isVertical
       ? layout.bottom
       : writingDirection === WritingDirection.LTR
-        ? layout.right
-        : layout.left;
+      ? layout.right
+      : layout.left;
 
     return isIncremental
       ? isSibling
         ? itemStart
         : itemEnd
       : isSibling
-        ? itemEnd
-        : itemStart;
+      ? itemEnd
+      : itemStart;
   }
 
   /**
@@ -407,7 +407,7 @@ class SpatialNavigationService {
     const intersectionLength = Math.max(
       0,
       Math.min(refCoordinateB, siblingCoordinateB) -
-      Math.max(refCoordinateA, siblingCoordinateA)
+        Math.max(refCoordinateA, siblingCoordinateA)
     );
 
     return intersectionLength >= thresholdDistance;
@@ -1071,12 +1071,12 @@ class SpatialNavigationService {
               ? siblingCutoffCoordinate >= currentCutoffCoordinate // vertical next
               : siblingCutoffCoordinate <= currentCutoffCoordinate // vertical previous
             : this.writingDirection === WritingDirection.LTR
-              ? isIncrementalDirection
-                ? siblingCutoffCoordinate >= currentCutoffCoordinate // horizontal LTR next
-                : siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal LTR previous
-              : isIncrementalDirection
-                ? siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal RTL next
-                : siblingCutoffCoordinate >= currentCutoffCoordinate; // horizontal RTL previous
+            ? isIncrementalDirection
+              ? siblingCutoffCoordinate >= currentCutoffCoordinate // horizontal LTR next
+              : siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal LTR previous
+            : isIncrementalDirection
+            ? siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal RTL next
+            : siblingCutoffCoordinate >= currentCutoffCoordinate; // horizontal RTL previous
         }
 
         return false;
@@ -1160,7 +1160,8 @@ class SpatialNavigationService {
       // eslint-disable-next-line no-console
       console.log(
         `%c${functionName}%c${debugString}`,
-        `background: ${DEBUG_FN_COLORS[this.logIndex % DEBUG_FN_COLORS.length]
+        `background: ${
+          DEBUG_FN_COLORS[this.logIndex % DEBUG_FN_COLORS.length]
         }; color: black; padding: 1px 5px;`,
         'background: #333; color: #BADA55; padding: 1px 5px;',
         ...rest

--- a/src/__tests__/SpatialNavigation.test.ts
+++ b/src/__tests__/SpatialNavigation.test.ts
@@ -129,12 +129,12 @@ describe('SpatialNavigation', () => {
       } as unknown as HTMLElement,
       isFocusBoundary: false,
       focusable: true,
-      onEnterPress: () => { },
-      onEnterRelease: () => { },
-      onFocus: () => { },
-      onBlur: () => { },
+      onEnterPress: () => {},
+      onEnterRelease: () => {},
+      onFocus: () => {},
+      onBlur: () => {},
       onArrowPress: () => true,
-      onArrowRelease: () => { },
+      onArrowRelease: () => {},
     });
 
     SpatialNavigation.navigateByDirection('right', {});

--- a/src/__tests__/SpatialNavigation.test.ts
+++ b/src/__tests__/SpatialNavigation.test.ts
@@ -129,11 +129,12 @@ describe('SpatialNavigation', () => {
       } as unknown as HTMLElement,
       isFocusBoundary: false,
       focusable: true,
-      onEnterPress: () => {},
-      onEnterRelease: () => {},
-      onFocus: () => {},
-      onBlur: () => {},
-      onArrowPress: () => true
+      onEnterPress: () => { },
+      onEnterRelease: () => { },
+      onFocus: () => { },
+      onBlur: () => { },
+      onArrowPress: () => true,
+      onArrowRelease: () => { },
     });
 
     SpatialNavigation.navigateByDirection('right', {});

--- a/src/__tests__/domNodes.ts
+++ b/src/__tests__/domNodes.ts
@@ -31,13 +31,14 @@ export const createRootNode = () => {
     forceFocus: true,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => {},
-    onEnterRelease: () => {},
-    onFocus: () => {},
-    onBlur: () => {},
+    onEnterPress: () => { },
+    onEnterRelease: () => { },
+    onFocus: () => { },
+    onBlur: () => { },
     onArrowPress: () => true,
-    onUpdateFocus: () => {},
-    onUpdateHasFocusedChild: () => {}
+    onArrowRelease: () => { },
+    onUpdateFocus: () => { },
+    onUpdateHasFocusedChild: () => { }
   });
 };
 
@@ -74,13 +75,14 @@ export const createHorizontalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => {},
-    onEnterRelease: () => {},
-    onFocus: () => {},
-    onBlur: () => {},
+    onEnterPress: () => { },
+    onEnterRelease: () => { },
+    onFocus: () => { },
+    onBlur: () => { },
     onArrowPress: () => true,
-    onUpdateFocus: () => {},
-    onUpdateHasFocusedChild: () => {}
+    onArrowRelease: () => { },
+    onUpdateFocus: () => { },
+    onUpdateHasFocusedChild: () => { }
   });
 
   SpatialNavigation.addFocusable({
@@ -113,13 +115,14 @@ export const createHorizontalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => {},
-    onEnterRelease: () => {},
-    onFocus: () => {},
-    onBlur: () => {},
+    onEnterPress: () => { },
+    onEnterRelease: () => { },
+    onFocus: () => { },
+    onBlur: () => { },
     onArrowPress: () => true,
-    onUpdateFocus: () => {},
-    onUpdateHasFocusedChild: () => {}
+    onArrowRelease: () => { },
+    onUpdateFocus: () => { },
+    onUpdateHasFocusedChild: () => { }
   });
 
   SpatialNavigation.addFocusable({
@@ -152,13 +155,14 @@ export const createHorizontalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => {},
-    onEnterRelease: () => {},
-    onFocus: () => {},
-    onBlur: () => {},
+    onEnterPress: () => { },
+    onEnterRelease: () => { },
+    onFocus: () => { },
+    onBlur: () => { },
     onArrowPress: () => true,
-    onUpdateFocus: () => {},
-    onUpdateHasFocusedChild: () => {}
+    onArrowRelease: () => { },
+    onUpdateFocus: () => { },
+    onUpdateHasFocusedChild: () => { }
   });
 };
 
@@ -195,13 +199,14 @@ export const createVerticalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => {},
-    onEnterRelease: () => {},
-    onFocus: () => {},
-    onBlur: () => {},
+    onEnterPress: () => { },
+    onEnterRelease: () => { },
+    onFocus: () => { },
+    onBlur: () => { },
     onArrowPress: () => true,
-    onUpdateFocus: () => {},
-    onUpdateHasFocusedChild: () => {}
+    onArrowRelease: () => { },
+    onUpdateFocus: () => { },
+    onUpdateHasFocusedChild: () => { }
   });
 
   SpatialNavigation.addFocusable({
@@ -234,12 +239,13 @@ export const createVerticalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => {},
-    onEnterRelease: () => {},
-    onFocus: () => {},
-    onBlur: () => {},
+    onEnterPress: () => { },
+    onEnterRelease: () => { },
+    onFocus: () => { },
+    onBlur: () => { },
     onArrowPress: () => true,
-    onUpdateFocus: () => {},
-    onUpdateHasFocusedChild: () => {}
+    onArrowRelease: () => { },
+    onUpdateFocus: () => { },
+    onUpdateHasFocusedChild: () => { }
   });
 };

--- a/src/__tests__/domNodes.ts
+++ b/src/__tests__/domNodes.ts
@@ -31,14 +31,14 @@ export const createRootNode = () => {
     forceFocus: true,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => { },
-    onEnterRelease: () => { },
-    onFocus: () => { },
-    onBlur: () => { },
+    onEnterPress: () => {},
+    onEnterRelease: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
     onArrowPress: () => true,
-    onArrowRelease: () => { },
-    onUpdateFocus: () => { },
-    onUpdateHasFocusedChild: () => { }
+    onArrowRelease: () => {},
+    onUpdateFocus: () => {},
+    onUpdateHasFocusedChild: () => {}
   });
 };
 
@@ -75,14 +75,14 @@ export const createHorizontalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => { },
-    onEnterRelease: () => { },
-    onFocus: () => { },
-    onBlur: () => { },
+    onEnterPress: () => {},
+    onEnterRelease: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
     onArrowPress: () => true,
-    onArrowRelease: () => { },
-    onUpdateFocus: () => { },
-    onUpdateHasFocusedChild: () => { }
+    onArrowRelease: () => {},
+    onUpdateFocus: () => {},
+    onUpdateHasFocusedChild: () => {}
   });
 
   SpatialNavigation.addFocusable({
@@ -115,14 +115,14 @@ export const createHorizontalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => { },
-    onEnterRelease: () => { },
-    onFocus: () => { },
-    onBlur: () => { },
+    onEnterPress: () => {},
+    onEnterRelease: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
     onArrowPress: () => true,
-    onArrowRelease: () => { },
-    onUpdateFocus: () => { },
-    onUpdateHasFocusedChild: () => { }
+    onArrowRelease: () => {},
+    onUpdateFocus: () => {},
+    onUpdateHasFocusedChild: () => {}
   });
 
   SpatialNavigation.addFocusable({
@@ -155,14 +155,14 @@ export const createHorizontalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => { },
-    onEnterRelease: () => { },
-    onFocus: () => { },
-    onBlur: () => { },
+    onEnterPress: () => {},
+    onEnterRelease: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
     onArrowPress: () => true,
-    onArrowRelease: () => { },
-    onUpdateFocus: () => { },
-    onUpdateHasFocusedChild: () => { }
+    onArrowRelease: () => {},
+    onUpdateFocus: () => {},
+    onUpdateHasFocusedChild: () => {}
   });
 };
 
@@ -199,14 +199,14 @@ export const createVerticalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => { },
-    onEnterRelease: () => { },
-    onFocus: () => { },
-    onBlur: () => { },
+    onEnterPress: () => {},
+    onEnterRelease: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
     onArrowPress: () => true,
-    onArrowRelease: () => { },
-    onUpdateFocus: () => { },
-    onUpdateHasFocusedChild: () => { }
+    onArrowRelease: () => {},
+    onUpdateFocus: () => {},
+    onUpdateHasFocusedChild: () => {}
   });
 
   SpatialNavigation.addFocusable({
@@ -239,13 +239,13 @@ export const createVerticalLayout = () => {
     forceFocus: false,
     autoRestoreFocus: true,
     saveLastFocusedChild: false,
-    onEnterPress: () => { },
-    onEnterRelease: () => { },
-    onFocus: () => { },
-    onBlur: () => { },
+    onEnterPress: () => {},
+    onEnterRelease: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
     onArrowPress: () => true,
-    onArrowRelease: () => { },
-    onUpdateFocus: () => { },
-    onUpdateHasFocusedChild: () => { }
+    onArrowRelease: () => {},
+    onUpdateFocus: () => {},
+    onUpdateHasFocusedChild: () => {}
   });
 };

--- a/src/useFocusable.ts
+++ b/src/useFocusable.ts
@@ -30,6 +30,11 @@ export type ArrowPressHandler<P = object> = (
   details: KeyPressDetails
 ) => boolean;
 
+export type ArrowReleaseHandler<P = object> = (
+  direction: string,
+  props: P,
+) => void;
+
 export type FocusHandler<P = object> = (
   layout: FocusableComponentLayout,
   props: P,
@@ -55,6 +60,7 @@ export interface UseFocusableConfig<P = object> {
   onEnterPress?: EnterPressHandler<P>;
   onEnterRelease?: EnterReleaseHandler<P>;
   onArrowPress?: ArrowPressHandler<P>;
+  onArrowRelease?: ArrowReleaseHandler<P>;
   onFocus?: FocusHandler<P>;
   onBlur?: BlurHandler<P>;
   extraProps?: P;
@@ -81,6 +87,7 @@ const useFocusableHook = <P>({
   onEnterPress = noop,
   onEnterRelease = noop,
   onArrowPress = () => true,
+  onArrowRelease = noop,
   onFocus = noop,
   onBlur = noop,
   extraProps
@@ -101,6 +108,10 @@ const useFocusableHook = <P>({
       onArrowPress(direction, extraProps, details),
     [extraProps, onArrowPress]
   );
+
+  const onArrowReleaseHandler = useCallback((direction: string) => {
+    onArrowRelease(direction, extraProps);
+  }, [onArrowRelease, extraProps])
 
   const onFocusHandler = useCallback(
     (layout: FocusableComponentLayout, details: FocusDetails) => {
@@ -149,6 +160,7 @@ const useFocusableHook = <P>({
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
       onArrowPress: onArrowPressHandler,
+      onArrowRelease: onArrowReleaseHandler,
       onFocus: onFocusHandler,
       onBlur: onBlurHandler,
       onUpdateFocus: (isFocused = false) => setFocused(isFocused),
@@ -182,6 +194,7 @@ const useFocusableHook = <P>({
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
       onArrowPress: onArrowPressHandler,
+      onArrowRelease: onArrowReleaseHandler,
       onFocus: onFocusHandler,
       onBlur: onBlurHandler
     });
@@ -194,6 +207,7 @@ const useFocusableHook = <P>({
     onEnterPressHandler,
     onEnterReleaseHandler,
     onArrowPressHandler,
+    onArrowReleaseHandler,
     onFocusHandler,
     onBlurHandler
   ]);


### PR DESCRIPTION
Resolves #143

Based on this issue: [Need onArrowRelease function param for useFocusable](https://github.com/NoriginMedia/Norigin-Spatial-Navigation/issues/143)

### Summary 
Implemented the `onArrowRelease` callback function in the `useFocusable` hook, allowing users to pass a custom function that is triggered when an arrow key is released.

### Usage
```
 const { ref, focused } = useFocusable({
    onArrowRelease: (direction: string) => {
        // do something when the target arrow key is released
    }
  });
```
### Demo
A `ProgressBar` component that allows progress to be updated by long-pressing the right arrow key.

https://github.com/user-attachments/assets/8b5ea6d3-1d45-4c2e-9de2-21c5b95e0bea


Looking forward to any feedback on the changes!