### PR TITLE
fix: native mode not updated focused state

### DIFF
--- a/src/SpatialNavigation.ts
+++ b/src/SpatialNavigation.ts
@@ -1609,7 +1609,7 @@ class SpatialNavigationService {
     // Cancel any pending auto-restore focus calls if we are setting focus manually
     this.setFocusDebounced.cancel();
 
-    if (!this.enabled || this.nativeMode) {
+    if (!this.enabled) {
       return;
     }
 


### PR DESCRIPTION
If we early return out of `setFocus` with `nativeMode` enabled - then the library will never be able to keep track of the focused elements, via calling `focusSelf`

I see the original change was introduced in this PR https://github.com/NoriginMedia/Norigin-Spatial-Navigation/pull/94#discussion_r1321590489 - which labels the change as Good. I'm not sure if we're missing a trick - but disabling the `setFocus` function when nativeMode is enabled means focus state can't be tracked.

As this is the only function that calls `setCurrentFocusedKey`, which updates the exported `focused` prop