### PR TITLE
Add extra compatibility for web bundlers like Vite or Webpack when using with React Native Web

### DIFF
--- a/.changeset/hungry-donuts-wave.md
+++ b/.changeset/hungry-donuts-wave.md
@@ -1,0 +1,5 @@
+---
+"@noriginmedia/norigin-spatial-navigation-react-native-tvos": patch
+---
+
+- Add extra compatibility for web bundlers like Vite or Webpack when using with React Native Web

--- a/packages/react-native-tvos/package.json
+++ b/packages/react-native-tvos/package.json
@@ -7,6 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "react-native": "./dist/index.mjs",
+      "browser": "./dist/index.web.mjs",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"

--- a/packages/react-native-tvos/rollup.config.mjs
+++ b/packages/react-native-tvos/rollup.config.mjs
@@ -4,12 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import { defineConfig } from 'rollup';
 
-export default defineConfig({
-  input: 'src/index.ts',
-  output: [
-    { file: 'dist/index.mjs', format: 'es' },
-    { file: 'dist/index.cjs', format: 'cjs' }
-  ],
+const baseConfig = {
   external: [
     '@noriginmedia/norigin-spatial-navigation-core',
     '@noriginmedia/norigin-spatial-navigation-react',
@@ -18,4 +13,23 @@ export default defineConfig({
     'react-native'
   ],
   plugins: [resolve(), commonjs(), typescript({ tsconfig: './tsconfig.json' })]
-});
+};
+
+export default defineConfig([
+  {
+    input: 'src/index.ts',
+    output: [
+      { file: 'dist/index.mjs', format: 'es' },
+      { file: 'dist/index.cjs', format: 'cjs' }
+    ],
+    ...baseConfig
+  },
+  {
+    input: 'src/index.web.ts',
+    output: [
+      { file: 'dist/index.web.mjs', format: 'es' },
+      { file: 'dist/index.web.cjs', format: 'cjs' }
+    ],
+    ...baseConfig
+  }
+]);

--- a/packages/react-native-tvos/src/index.web.ts
+++ b/packages/react-native-tvos/src/index.web.ts
@@ -1,0 +1,2 @@
+export { BaseWebAdapter as ReactNativeLayoutAdapter } from '@noriginmedia/norigin-spatial-navigation-core';
+export * from '@noriginmedia/norigin-spatial-navigation-react';


### PR DESCRIPTION
- Updated rollup configuration to support separate builds for web and common JS formats.
- Added new entry point for web-specific functionality in src/index.web.ts.
- Updated package.json exports to include web module paths.