### PR TITLE
Add nextFocusResolver to override default behavior

### DIFF
--- a/.changeset/hot-falcons-begin.md
+++ b/.changeset/hot-falcons-begin.md
@@ -1,0 +1,6 @@
+---
+"@noriginmedia/norigin-spatial-navigation-core": patch
+"@noriginmedia/norigin-spatial-navigation-react": patch
+---
+
+- Add `nextFocusResolver` to override default behavior

--- a/packages/core/src/SpatialNavigation.ts
+++ b/packages/core/src/SpatialNavigation.ts
@@ -37,6 +37,12 @@ export type NodeType = NodeTypeOverrides extends { node: infer N }
 
 export type Direction = 'up' | 'down' | 'left' | 'right';
 
+export type NavigationStrategy = (
+  direction: Direction,
+  focusKey: string,
+  siblings: FocusableComponent[]
+) => FocusableComponent | null;
+
 type DistanceCalculationMethod = 'center' | 'edges' | 'corners';
 
 type DistanceCalculationFunction = (
@@ -112,6 +118,7 @@ export interface FocusableComponent {
   focusBoundaryDirections?: Direction[];
   autoRestoreFocus: boolean;
   forceFocus: boolean;
+  navigationStrategy?: NavigationStrategy;
   lastFocusedChildKey?: string;
   layout?: FocusableComponentLayout;
   layoutUpdatedAt?: number;
@@ -131,6 +138,7 @@ interface FocusableComponentUpdatePayload {
   onFocus: (layout: FocusableComponentLayout, details: FocusDetails) => void;
   onBlur: (layout: FocusableComponentLayout, details: FocusDetails) => void;
   accessibilityLabel?: string;
+  navigationStrategy?: NavigationStrategy;
 }
 
 interface FocusableComponentRemovePayload {
@@ -1133,73 +1141,99 @@ export class SpatialNavigationService {
           .map((component) => this.updateLayout(component.focusKey))
       );
 
-      const siblings = filter(this.focusableComponents, (component) => {
-        if (
-          component.parentFocusKey === parentFocusKey &&
-          component.focusKey !== currentComponent.focusKey &&
-          component.focusable &&
-          component.layout
-        ) {
-          const siblingCutoffCoordinate =
-            SpatialNavigationService.getCutoffCoordinate(
-              isVerticalDirection,
-              isIncrementalDirection,
-              true,
-              component.layout,
-              this.writingDirection
-            );
+      let nextComponent: FocusableComponent | null = null;
 
-          return isVerticalDirection
-            ? isIncrementalDirection
-              ? siblingCutoffCoordinate >= currentCutoffCoordinate // vertical next
-              : siblingCutoffCoordinate <= currentCutoffCoordinate // vertical previous
-            : this.writingDirection === WritingDirection.LTR
-            ? isIncrementalDirection
-              ? siblingCutoffCoordinate >= currentCutoffCoordinate // horizontal LTR next
-              : siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal LTR previous
-            : isIncrementalDirection
-            ? siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal RTL next
-            : siblingCutoffCoordinate >= currentCutoffCoordinate; // horizontal RTL previous
+      const { navigationStrategy } =
+        this.focusableComponents[parentFocusKey] ?? {};
+
+      if (navigationStrategy) {
+        const siblings = filter(
+          this.focusableComponents,
+          (component) =>
+            component.parentFocusKey === parentFocusKey && component.focusable
+        );
+        nextComponent = navigationStrategy(
+          direction as Direction,
+          focusKey,
+          siblings
+        );
+
+        if (this.debug) {
+          this.log(
+            'smartNavigate',
+            'navigation overrided by navigationStrategy',
+            nextComponent
+          );
+        }
+      } else {
+        const siblings = filter(this.focusableComponents, (component) => {
+          if (
+            component.parentFocusKey === parentFocusKey &&
+            component.focusKey !== currentComponent.focusKey &&
+            component.focusable &&
+            component.layout
+          ) {
+            const siblingCutoffCoordinate =
+              SpatialNavigationService.getCutoffCoordinate(
+                isVerticalDirection,
+                isIncrementalDirection,
+                true,
+                component.layout,
+                this.writingDirection
+              );
+
+            return isVerticalDirection
+              ? isIncrementalDirection
+                ? siblingCutoffCoordinate >= currentCutoffCoordinate // vertical next
+                : siblingCutoffCoordinate <= currentCutoffCoordinate // vertical previous
+              : this.writingDirection === WritingDirection.LTR
+              ? isIncrementalDirection
+                ? siblingCutoffCoordinate >= currentCutoffCoordinate // horizontal LTR next
+                : siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal LTR previous
+              : isIncrementalDirection
+              ? siblingCutoffCoordinate <= currentCutoffCoordinate // horizontal RTL next
+              : siblingCutoffCoordinate >= currentCutoffCoordinate; // horizontal RTL previous
+          }
+
+          return false;
+        });
+
+        if (this.debug) {
+          this.log(
+            'smartNavigate',
+            'currentCutoffCoordinate',
+            currentCutoffCoordinate
+          );
+          this.log(
+            'smartNavigate',
+            'siblings',
+            `${siblings.length} elements:`,
+            siblings.map((sibling) => sibling.focusKey).join(', '),
+            siblings.map((sibling) => sibling.node),
+            siblings.map((sibling) => sibling)
+          );
         }
 
-        return false;
-      });
+        if (this.visualDebugger) {
+          const refCorners = SpatialNavigationService.getRefCorners(
+            direction,
+            false,
+            layout
+          );
 
-      if (this.debug) {
-        this.log(
-          'smartNavigate',
-          'currentCutoffCoordinate',
-          currentCutoffCoordinate
-        );
-        this.log(
-          'smartNavigate',
-          'siblings',
-          `${siblings.length} elements:`,
-          siblings.map((sibling) => sibling.focusKey).join(', '),
-          siblings.map((sibling) => sibling.node),
-          siblings.map((sibling) => sibling)
-        );
-      }
+          this.visualDebugger.drawPoint(refCorners.a.x, refCorners.a.y);
+          this.visualDebugger.drawPoint(refCorners.b.x, refCorners.b.y);
+        }
 
-      if (this.visualDebugger) {
-        const refCorners = SpatialNavigationService.getRefCorners(
+        const sortedSiblings = this.sortSiblingsByPriority(
+          siblings,
+          layout,
           direction,
-          false,
-          layout
+          focusKey
         );
 
-        this.visualDebugger.drawPoint(refCorners.a.x, refCorners.a.y);
-        this.visualDebugger.drawPoint(refCorners.b.x, refCorners.b.y);
+        nextComponent = first(sortedSiblings);
       }
-
-      const sortedSiblings = this.sortSiblingsByPriority(
-        siblings,
-        layout,
-        direction,
-        focusKey
-      );
-
-      const nextComponent = first(sortedSiblings);
 
       this.log(
         'smartNavigate',
@@ -1405,7 +1439,8 @@ export class SpatialNavigationService {
     focusable,
     isFocusBoundary,
     focusBoundaryDirections,
-    accessibilityLabel
+    accessibilityLabel,
+    navigationStrategy
   }: FocusableComponent) {
     this.focusableComponents[focusKey] = {
       focusKey,
@@ -1419,6 +1454,7 @@ export class SpatialNavigationService {
       onBlur,
       onUpdateFocus,
       onUpdateHasFocusedChild,
+      navigationStrategy,
       saveLastFocusedChild,
       trackChildren,
       preferredChildFocusKey,
@@ -1857,7 +1893,8 @@ export class SpatialNavigationService {
       onArrowPress,
       onFocus,
       onBlur,
-      accessibilityLabel
+      accessibilityLabel,
+      navigationStrategy
     }: FocusableComponentUpdatePayload
   ) {
     const component = this.focusableComponents[focusKey];
@@ -1873,6 +1910,7 @@ export class SpatialNavigationService {
       component.onFocus = onFocus;
       component.onBlur = onBlur;
       component.accessibilityLabel = accessibilityLabel;
+      component.navigationStrategy = navigationStrategy;
       // Reset layout updated at to force a layout update
       component.layoutUpdatedAt = 0;
 

--- a/packages/core/src/SpatialNavigation.ts
+++ b/packages/core/src/SpatialNavigation.ts
@@ -1167,7 +1167,7 @@ export class SpatialNavigationService {
 
           this.log(
             'smartNavigate',
-            'navigation overrided by nextFocusResolver',
+            'navigation overridden by nextFocusResolver',
             nextComponent
           );
         }

--- a/packages/core/src/SpatialNavigation.ts
+++ b/packages/core/src/SpatialNavigation.ts
@@ -37,7 +37,7 @@ export type NodeType = NodeTypeOverrides extends { node: infer N }
 
 export type Direction = 'up' | 'down' | 'left' | 'right';
 
-export type NavigationStrategy = (
+export type NextFocusResolver = (
   direction: Direction,
   focusKey: string,
   siblings: FocusableComponent[]
@@ -118,7 +118,7 @@ export interface FocusableComponent {
   focusBoundaryDirections?: Direction[];
   autoRestoreFocus: boolean;
   forceFocus: boolean;
-  navigationStrategy?: NavigationStrategy;
+  nextFocusResolver?: NextFocusResolver;
   lastFocusedChildKey?: string;
   layout?: FocusableComponentLayout;
   layoutUpdatedAt?: number;
@@ -138,7 +138,7 @@ interface FocusableComponentUpdatePayload {
   onFocus: (layout: FocusableComponentLayout, details: FocusDetails) => void;
   onBlur: (layout: FocusableComponentLayout, details: FocusDetails) => void;
   accessibilityLabel?: string;
-  navigationStrategy?: NavigationStrategy;
+  nextFocusResolver?: NextFocusResolver;
 }
 
 interface FocusableComponentRemovePayload {
@@ -1143,16 +1143,16 @@ export class SpatialNavigationService {
 
       let nextComponent: FocusableComponent | null = null;
 
-      const { navigationStrategy } =
+      const { nextFocusResolver } =
         this.focusableComponents[parentFocusKey] ?? {};
 
-      if (navigationStrategy) {
+      if (nextFocusResolver) {
         const siblings = filter(
           this.focusableComponents,
           (component) =>
             component.parentFocusKey === parentFocusKey && component.focusable
         );
-        nextComponent = navigationStrategy(
+        nextComponent = nextFocusResolver(
           direction as Direction,
           focusKey,
           siblings
@@ -1161,7 +1161,7 @@ export class SpatialNavigationService {
         if (this.debug) {
           this.log(
             'smartNavigate',
-            'navigation overrided by navigationStrategy',
+            'navigation overrided by nextFocusResolver',
             nextComponent
           );
         }
@@ -1440,7 +1440,7 @@ export class SpatialNavigationService {
     isFocusBoundary,
     focusBoundaryDirections,
     accessibilityLabel,
-    navigationStrategy
+    nextFocusResolver
   }: FocusableComponent) {
     this.focusableComponents[focusKey] = {
       focusKey,
@@ -1454,7 +1454,7 @@ export class SpatialNavigationService {
       onBlur,
       onUpdateFocus,
       onUpdateHasFocusedChild,
-      navigationStrategy,
+      nextFocusResolver,
       saveLastFocusedChild,
       trackChildren,
       preferredChildFocusKey,
@@ -1894,7 +1894,7 @@ export class SpatialNavigationService {
       onFocus,
       onBlur,
       accessibilityLabel,
-      navigationStrategy
+      nextFocusResolver
     }: FocusableComponentUpdatePayload
   ) {
     const component = this.focusableComponents[focusKey];
@@ -1910,7 +1910,7 @@ export class SpatialNavigationService {
       component.onFocus = onFocus;
       component.onBlur = onBlur;
       component.accessibilityLabel = accessibilityLabel;
-      component.navigationStrategy = navigationStrategy;
+      component.nextFocusResolver = nextFocusResolver;
       // Reset layout updated at to force a layout update
       component.layoutUpdatedAt = 0;
 

--- a/packages/core/src/SpatialNavigation.ts
+++ b/packages/core/src/SpatialNavigation.ts
@@ -1159,6 +1159,12 @@ export class SpatialNavigationService {
         );
 
         if (this.debug) {
+          if (nextComponent != null && !siblings.includes(nextComponent)) {
+            console.warn(
+              `nextFocusResolver returned an invalid component. This will result in lost focus. Check the "nextFocusResolver" implementation in component with focusKey: ${parentFocusKey}`
+            );
+          }
+
           this.log(
             'smartNavigate',
             'navigation overrided by nextFocusResolver',

--- a/packages/react/src/useFocusable.ts
+++ b/packages/react/src/useFocusable.ts
@@ -13,7 +13,7 @@ import {
   FocusDetails,
   KeyPressDetails,
   Direction,
-  NavigationStrategy
+  NextFocusResolver
 } from '@noriginmedia/norigin-spatial-navigation-core';
 import { useFocusContext } from './useFocusContext';
 
@@ -57,7 +57,7 @@ export interface UseFocusableConfig<P = object> {
   focusBoundaryDirections?: Direction[];
   focusKey?: string;
   preferredChildFocusKey?: string;
-  navigationStrategy?: NavigationStrategy;
+  nextFocusResolver?: NextFocusResolver;
   onEnterPress?: EnterPressHandler<P>;
   onEnterRelease?: EnterReleaseHandler<P>;
   onArrowPress?: ArrowPressHandler<P>;
@@ -92,7 +92,7 @@ const useFocusableHook = <P, E = any>({
   focusBoundaryDirections,
   focusKey: propFocusKey,
   preferredChildFocusKey,
-  navigationStrategy,
+  nextFocusResolver,
   onEnterPress = noop,
   onEnterRelease = noop,
   onArrowPress = () => true,
@@ -170,7 +170,7 @@ const useFocusableHook = <P, E = any>({
       node,
       parentFocusKey,
       preferredChildFocusKey,
-      navigationStrategy,
+      nextFocusResolver,
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
       onArrowPress: onArrowPressHandler,
@@ -206,7 +206,7 @@ const useFocusableHook = <P, E = any>({
       focusable,
       isFocusBoundary,
       focusBoundaryDirections,
-      navigationStrategy,
+      nextFocusResolver,
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
       onArrowPress: onArrowPressHandler,
@@ -221,7 +221,7 @@ const useFocusableHook = <P, E = any>({
     focusable,
     isFocusBoundary,
     focusBoundaryDirections,
-    navigationStrategy,
+    nextFocusResolver,
     onEnterPressHandler,
     onEnterReleaseHandler,
     onArrowPressHandler,

--- a/packages/react/src/useFocusable.ts
+++ b/packages/react/src/useFocusable.ts
@@ -12,7 +12,8 @@ import {
   FocusableComponentLayout,
   FocusDetails,
   KeyPressDetails,
-  Direction
+  Direction,
+  NavigationStrategy
 } from '@noriginmedia/norigin-spatial-navigation-core';
 import { useFocusContext } from './useFocusContext';
 
@@ -56,6 +57,7 @@ export interface UseFocusableConfig<P = object> {
   focusBoundaryDirections?: Direction[];
   focusKey?: string;
   preferredChildFocusKey?: string;
+  navigationStrategy?: NavigationStrategy;
   onEnterPress?: EnterPressHandler<P>;
   onEnterRelease?: EnterReleaseHandler<P>;
   onArrowPress?: ArrowPressHandler<P>;
@@ -90,6 +92,7 @@ const useFocusableHook = <P, E = any>({
   focusBoundaryDirections,
   focusKey: propFocusKey,
   preferredChildFocusKey,
+  navigationStrategy,
   onEnterPress = noop,
   onEnterRelease = noop,
   onArrowPress = () => true,
@@ -167,6 +170,7 @@ const useFocusableHook = <P, E = any>({
       node,
       parentFocusKey,
       preferredChildFocusKey,
+      navigationStrategy,
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
       onArrowPress: onArrowPressHandler,
@@ -202,6 +206,7 @@ const useFocusableHook = <P, E = any>({
       focusable,
       isFocusBoundary,
       focusBoundaryDirections,
+      navigationStrategy,
       onEnterPress: onEnterPressHandler,
       onEnterRelease: onEnterReleaseHandler,
       onArrowPress: onArrowPressHandler,
@@ -216,6 +221,7 @@ const useFocusableHook = <P, E = any>({
     focusable,
     isFocusBoundary,
     focusBoundaryDirections,
+    navigationStrategy,
     onEnterPressHandler,
     onEnterReleaseHandler,
     onArrowPressHandler,


### PR DESCRIPTION
## Summary
Adds an optional **`nextFocusResolver`** hook so a parent focus scope can override default spatial navigation when moving between siblings. When set on the **parent** focusable, arrow navigation among its children uses your function instead of cutoff coordinates and priority sorting.
## Motivation
Default spatial navigation is geometry-based (cutoff coordinates, RTL/LTR, `sortSiblingsByPriority`). Some UIs need deterministic or domain-specific ordering (e.g. custom grids, masked lists, non-rect layouts, overlapped elements...). This change lets callers supply the next focus target explicitly while keeping the existing algorithm as the default when no strategy is provided.
## API
- **Type** `NextFocusResolver`:
  ```ts
  (
    direction: Direction,
    focusKey: string,
    siblings: FocusableComponent[]
  ) => FocusableComponent | null
`FocusableComponent.navigationStrategy` (optional) — stored and updated with addFocusable / updateFocusable.
`useFocusable({ navigationStrategy })` — passes the strategy through registration and dependency updates.

## Behavior
During smartNavigate, the service reads nextFocusResolver from the parent (focusableComponents[parentFocusKey]).
If present: collects siblings with the same parentFocusKey that are focusable, calls nextFocusResolver(direction, focusKey, siblings), and uses its return value as the next component (skips default sibling filtering by layout cutoff, visual-debug sibling drawing for that path, and sortSiblingsByPriority).