### PR TITLE
Fixed TypeError due to race condition in node onFocus and onBlur promises

### DIFF
--- a/.changeset/async-focus-blur-issue.md
+++ b/.changeset/async-focus-blur-issue.md
@@ -1,0 +1,5 @@
+---
+"@noriginmedia/norigin-spatial-navigation-core": patch
+---
+
+Fixed a small race condition in  `onIntermediateNodeBecameBlurred` and `onIntermediateNodeBecameFocused` by checking the component still exists inside promise resolve.

--- a/.changeset/async-focus-blur-issue.md
+++ b/.changeset/async-focus-blur-issue.md
@@ -2,4 +2,4 @@
 "@noriginmedia/norigin-spatial-navigation-core": patch
 ---
 
-Fixed a small race condition in  `onIntermediateNodeBecameBlurred` and `onIntermediateNodeBecameFocused` by checking the component still exists inside promise resolve.
+Fix for a race condition where `onIntermediateNodeBecameBlurred` and `onIntermediateNodeBecameFocused` functions could throw a _TypeError_ if the component no longer existed once promises resolve.

--- a/packages/core/src/SpatialNavigation.ts
+++ b/packages/core/src/SpatialNavigation.ts
@@ -1776,7 +1776,7 @@ export class SpatialNavigationService {
   ) {
     if (this.isParticipatingFocusableComponent(focusKey)) {
       this.getNodeLayoutByFocusKey(focusKey).then((layout) => {
-        this.focusableComponents[focusKey].onFocus(layout, focusDetails);
+        this.focusableComponents[focusKey]?.onFocus(layout, focusDetails);
       });
     }
   }
@@ -1787,7 +1787,7 @@ export class SpatialNavigationService {
   ) {
     if (this.isParticipatingFocusableComponent(focusKey)) {
       this.getNodeLayoutByFocusKey(focusKey).then((layout) => {
-        this.focusableComponents[focusKey].onBlur(layout, focusDetails);
+        this.focusableComponents[focusKey]?.onBlur(layout, focusDetails);
       });
     }
   }


### PR DESCRIPTION
### Fixed
- Race condition where `onIntermediateNodeBecameBlurred` and `onIntermediateNodeBecameFocused` functions could throw a _TypeError_ if the component no longer existed once promises resolve